### PR TITLE
Review: Evaluation/benchmarking scripts (David)

### DIFF
--- a/evaluation/benchmarking_inversion-2-retry.py
+++ b/evaluation/benchmarking_inversion-2-retry.py
@@ -1,0 +1,125 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+df = pd.read_csv("/data/david/final_tasks_prompts/dataset_swapped500k_prompt.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+print(test_df.columns)
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+llm = LLM(model="/data/share/sft_hf_3/")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+def extract_answer(text):
+    m = re.search(r"<answer>\s*([ABCD])\s*</answer>", text, re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+    m2 = re.search(r"([ABCD])\s*</answer>", text, re.IGNORECASE)
+    if m2:
+        return m2.group(1).upper()
+
+    return None
+
+letters = ["A","B","C","D"]
+
+
+prompts       = []
+gold_letters  = []
+for ex in test_data:
+    true_rx = ex["true_reaction"]
+    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
+    
+    opts = np.random.permutation([true_rx] + fakes).tolist()
+    
+    gold_letters.append( letters[ opts.index(true_rx) ] )
+    
+    prompt = (
+        "<|im_start|>assistant\n"
+        "You are a useful Chemistry assistant and will answer the following MCQ.\n"
+        "Give your reasoning inside <think>...</think> tags, then respond with the option letter\n"
+        "inside <answer>...</answer> tags. Think through all four options (A, B, C, D)\n"
+        "before choosing your final answer.\n"
+        "<|im_end|>\n\n"
+        "<|im_start|>user\n"
+        "Question: Which chemical reaction is correct? Choose from the following options:\n"
+        f"A. {opts[0]}\n"
+        f"B. {opts[1]}\n"
+        f"C. {opts[2]}\n"
+        f"D. {opts[3]}\n"
+        "Make sure to give your choice A, B, C, or D inside the <answer>...</answer> tags.\n"
+        "<|im_end|>\n\n"
+        "<|im_start|>assistant\n"
+        "<think>"
+    )
+    prompts.append(prompt)
+
+if needs_retry:
+    retry_prompts = [
+        prompts[i] + completions[i] + "\n<answer>"
+        for i in needs_retry
+    ]
+    print(f"Retrying {len(needs_retry)} examples: {needs_retry}")
+    retry_results = llm.generate(retry_prompts, sampling_params)
+
+    for idx, res in zip(needs_retry, retry_results):
+        old = completions[idx]
+        new = res.outputs[0].text
+
+        print(f"\nExample #{idx} – before vs. after")
+        print("OLD:", old)
+        print("NEW:", new)
+
+        if extract_answer(new) is not None:
+            merged = old + new
+            print("Merged retry for index", idx)
+            completions[idx] = merged
+        else:
+            print("Still no tag at index", idx)
+
+correct = 0
+records = []
+for i, (gold, comp) in enumerate(zip(gold_letters, completions), start=1):
+    pred = extract_answer(comp)
+    hit  = (pred == gold)
+    if hit:
+        correct += 1
+        records.append({
+            "example_idx": i,
+            "gold_letter": gold,
+            "predicted":   pred,
+            "completion":  comp
+        })
+    print(f"Example #{i}: gold={gold} pred={pred} → {'OK' if hit else 'WRONG'}")
+
+acc = 100 * correct / len(test_data)
+print(f"\nFinal any-of-5 accuracy: {acc:.2f}% ({correct}/{len(test_data)})")
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_correct_completions_think.csv", index=False)
+print(f"Saved {len(out_df)} correct completions to inversion_2_correct_completions_think.csv")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(acc, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_inversion-2-retry.py
+++ b/evaluation/benchmarking_inversion-2-retry.py
@@ -1,32 +1,53 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
-import pandas as pd
-from sklearn.model_selection import train_test_split
+import re
+
 import numpy as np
+import pandas as pd
+from rdkit import Chem
+from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/dataset_swapped500k_prompt.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 print(test_df.columns)
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-llm = LLM(model="/data/share/sft_hf_3/")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/sft_hf_3/")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
 
 def extract_answer(text):
     m = re.search(r"<answer>\s*([ABCD])\s*</answer>", text, re.IGNORECASE)
@@ -38,19 +59,20 @@ def extract_answer(text):
 
     return None
 
-letters = ["A","B","C","D"]
+
+letters = ["A", "B", "C", "D"]
 
 
-prompts       = []
-gold_letters  = []
+prompts = []
+gold_letters = []
 for ex in test_data:
     true_rx = ex["true_reaction"]
-    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
-    
+    fakes = [ex["fake1"], ex["fake2"], ex["fake3"]]
+
     opts = np.random.permutation([true_rx] + fakes).tolist()
-    
-    gold_letters.append( letters[ opts.index(true_rx) ] )
-    
+
+    gold_letters.append(letters[opts.index(true_rx)])
+
     prompt = (
         "<|im_start|>assistant\n"
         "You are a useful Chemistry assistant and will answer the following MCQ.\n"
@@ -72,10 +94,7 @@ for ex in test_data:
     prompts.append(prompt)
 
 if needs_retry:
-    retry_prompts = [
-        prompts[i] + completions[i] + "\n<answer>"
-        for i in needs_retry
-    ]
+    retry_prompts = [prompts[i] + completions[i] + "\n<answer>" for i in needs_retry]
     print(f"Retrying {len(needs_retry)} examples: {needs_retry}")
     retry_results = llm.generate(retry_prompts, sampling_params)
 
@@ -98,15 +117,10 @@ correct = 0
 records = []
 for i, (gold, comp) in enumerate(zip(gold_letters, completions), start=1):
     pred = extract_answer(comp)
-    hit  = (pred == gold)
+    hit = pred == gold
     if hit:
         correct += 1
-        records.append({
-            "example_idx": i,
-            "gold_letter": gold,
-            "predicted":   pred,
-            "completion":  comp
-        })
+        records.append({"example_idx": i, "gold_letter": gold, "predicted": pred, "completion": comp})
     print(f"Example #{i}: gold={gold} pred={pred} → {'OK' if hit else 'WRONG'}")
 
 acc = 100 * correct / len(test_data)
@@ -116,10 +130,6 @@ out_df = pd.DataFrame(records)
 out_df.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_correct_completions_think.csv", index=False)
 print(f"Saved {len(out_df)} correct completions to inversion_2_correct_completions_think.csv")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(acc, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(acc, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_inversion-2.py
+++ b/evaluation/benchmarking_inversion-2.py
@@ -1,32 +1,53 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
-import pandas as pd
-from sklearn.model_selection import train_test_split
+import re
+
 import numpy as np
+import pandas as pd
+from rdkit import Chem
+from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/dataset_swapped500k_prompt.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 print(test_df.columns)
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-llm = LLM(model="/data/share/sft_hf_3/")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/sft_hf_3/")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
 
 def extract_answer(text):
     m = re.search(r"<answer>\s*([ABCD])\s*</answer>", text, re.IGNORECASE)
@@ -38,19 +59,20 @@ def extract_answer(text):
 
     return None
 
-letters = ["A","B","C","D"]
+
+letters = ["A", "B", "C", "D"]
 
 
-prompts       = []
-gold_letters  = []
+prompts = []
+gold_letters = []
 for ex in test_data:
     true_rx = ex["true_reaction"]
-    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
-    
+    fakes = [ex["fake1"], ex["fake2"], ex["fake3"]]
+
     opts = np.random.permutation([true_rx] + fakes).tolist()
-    
-    gold_letters.append( letters[ opts.index(true_rx) ] )
-    
+
+    gold_letters.append(letters[opts.index(true_rx)])
+
     prompt = (
         "<|im_start|>assistant\n"
         "You are a useful Chemistry assistant and will answer the following MCQ.\n"
@@ -79,36 +101,38 @@ correct = 0
 for idx, (gold, out, prompt) in enumerate(zip(gold_letters, outputs, prompts), 1):
     print(f"\n=== Example #{idx} (gold={gold}) ===")
     hit = False
-    
+
     for j, sample in enumerate(out.outputs, 1):
         text = sample.text
         pred = extract_answer(text)
-        ok   = (pred == gold)
-        
+        ok = pred == gold
+
         if ok:
             print(f"\n*** CORRECT SAMPLE (Example {idx}, Sample {j}) ***")
             print("Prompt:\n", prompt)
             print("Completion:\n", text)
             print(f"Predicted: {pred!r}   Gold: {gold!r}\n")
         else:
-          
+
             if np.random.rand() < 0.5:
                 print(f"\n*** INCORRECT SAMPLE (Example {idx}, Sample {j}) ***")
                 print("Predicted:", pred, "Gold:", gold)
                 print(text[:300], "…\n")
-        
+
         if ok and not hit:
             correct += 1
             hit = True
-            
-            records.append({
-                "example_idx":      idx,
-                "gold_letter":      gold,
-                "predicted_letter": pred,
-                "prompt":           prompt,
-                "completion":       text
-            })
-            break  
+
+            records.append(
+                {
+                    "example_idx": idx,
+                    "gold_letter": gold,
+                    "predicted_letter": pred,
+                    "prompt": prompt,
+                    "completion": text,
+                }
+            )
+            break
 
     print(f"Example {idx} any-of-5 correct? {'OK' if hit else 'WRONG'}")
 
@@ -119,10 +143,6 @@ out_df = pd.DataFrame(records)
 out_df.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_correct_completions_think.csv", index=False)
 print(f"Saved {len(out_df)} correct completions to inversion_2_correct_completions_think.csv")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(acc, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(acc, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_inversion-2.py
+++ b/evaluation/benchmarking_inversion-2.py
@@ -1,0 +1,128 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+df = pd.read_csv("/data/david/final_tasks_prompts/dataset_swapped500k_prompt.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+print(test_df.columns)
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+llm = LLM(model="/data/share/sft_hf_3/")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+def extract_answer(text):
+    m = re.search(r"<answer>\s*([ABCD])\s*</answer>", text, re.IGNORECASE)
+    if m:
+        return m.group(1).upper()
+    m2 = re.search(r"([ABCD])\s*</answer>", text, re.IGNORECASE)
+    if m2:
+        return m2.group(1).upper()
+
+    return None
+
+letters = ["A","B","C","D"]
+
+
+prompts       = []
+gold_letters  = []
+for ex in test_data:
+    true_rx = ex["true_reaction"]
+    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
+    
+    opts = np.random.permutation([true_rx] + fakes).tolist()
+    
+    gold_letters.append( letters[ opts.index(true_rx) ] )
+    
+    prompt = (
+        "<|im_start|>assistant\n"
+        "You are a useful Chemistry assistant and will answer the following MCQ.\n"
+        "Give your reasoning inside <think>...</think> tags, then respond with the option letter\n"
+        "inside <answer>...</answer> tags. Think through all four options (A, B, C, D)\n"
+        "before choosing your final answer.\n"
+        "<|im_end|>\n\n"
+        "<|im_start|>user\n"
+        "Question: Which chemical reaction is correct? Choose from the following options:\n"
+        f"A. {opts[0]}\n"
+        f"B. {opts[1]}\n"
+        f"C. {opts[2]}\n"
+        f"D. {opts[3]}\n"
+        "Make sure to give your choice A, B, C, or D inside the <answer>...</answer> tags.\n"
+        "<|im_end|>\n\n"
+        "<|im_start|>assistant\n"
+        "<think>"
+    )
+    prompts.append(prompt)
+
+outputs = llm.generate(prompts, sampling_params)
+
+records = []
+correct = 0
+
+for idx, (gold, out, prompt) in enumerate(zip(gold_letters, outputs, prompts), 1):
+    print(f"\n=== Example #{idx} (gold={gold}) ===")
+    hit = False
+    
+    for j, sample in enumerate(out.outputs, 1):
+        text = sample.text
+        pred = extract_answer(text)
+        ok   = (pred == gold)
+        
+        if ok:
+            print(f"\n*** CORRECT SAMPLE (Example {idx}, Sample {j}) ***")
+            print("Prompt:\n", prompt)
+            print("Completion:\n", text)
+            print(f"Predicted: {pred!r}   Gold: {gold!r}\n")
+        else:
+          
+            if np.random.rand() < 0.5:
+                print(f"\n*** INCORRECT SAMPLE (Example {idx}, Sample {j}) ***")
+                print("Predicted:", pred, "Gold:", gold)
+                print(text[:300], "…\n")
+        
+        if ok and not hit:
+            correct += 1
+            hit = True
+            
+            records.append({
+                "example_idx":      idx,
+                "gold_letter":      gold,
+                "predicted_letter": pred,
+                "prompt":           prompt,
+                "completion":       text
+            })
+            break  
+
+    print(f"Example {idx} any-of-5 correct? {'OK' if hit else 'WRONG'}")
+
+acc = 100 * correct / len(test_data)
+print(f"\nFinal any-of-5 accuracy: {acc:.2f}% ({correct}/{len(test_data)})")
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_correct_completions_think.csv", index=False)
+print(f"Saved {len(out_df)} correct completions to inversion_2_correct_completions_think.csv")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(acc, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/inversion_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_naming-2-retry.py
+++ b/evaluation/benchmarking_naming-2-retry.py
@@ -1,0 +1,197 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+df = pd.read_csv("/data/david/final_tasks_prompts/reaction_class_prompts_600k.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+
+test_df = test_df.drop(columns=["Unnamed: 0", "REACTION"])
+
+test_df = test_df.rename(columns={
+    "REACTION_PROMPT": "input",
+    "CLASS":           "answer"
+})
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+# llm = LLM(model="/data/share/jgoumaz_grpo_models/checkpoints/rxn_naming_409465/checkpoint-200/")  
+# llm = LLM(model="Qwen/Qwen2.5-3B", trust_remote_code=True)
+llm = LLM(model="/data/share/qwen_pretranined_v6")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+def extract_answer(text):
+    m = re.search(r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL|re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    m2 = re.search(r"([A-Za-z \-]+?)\s*</answer>", text, re.IGNORECASE)
+    return m2.group(1).strip() if m2 else None
+
+classes = [
+    "Acylation",
+    "Aromatic Heterocycle Formation",
+    "C-C Coupling",
+    "Deprotection",
+    "Functional Group Addition",
+    "Functional Group Interconversion",
+    "Heteroatom Alkylation and Arylation",
+    "Miscellaneous",
+    "Protection",
+    "Reduction",
+]
+
+
+prompts = []
+for ex in test_data:
+    inp = ex["input"].replace("<answer>", "")
+    opts = "\n".join(f"- {cls}" for cls in classes)
+
+    # prompt = (
+    #     "<|im_start|>assistant\n"
+    #     "You are a useful Chemistry assistant.\n"
+    #     "Think about your choice and output your reasoning within <think> ... </think> tags.\n"
+    #     "Make sure to put your final choice inside <answer>…</answer>.\n"
+    #     "<|im_end|>\n"
+    #     "<|im_start|>user\n"
+    #     f"Question: What is the name of this chemical reaction?\n{inp}\n"
+    #     "Choose **only** from the following list:\n"
+    #     f"{opts}\n"
+    #     "<|im_end|>\n"
+    #     "<|im_start|>assistant\n"
+    #     "<think>"
+    # )
+    prompt = f"""<|im_start|>assistant
+        You are a useful Chemistry assistant and you will answer the following class prediction question. Give your reasoning inside the <think>...</think> tags and then respond inside <answer>...</answer> tags, think and reason for all the options before giving your answer. Structure your reasoning such that you think through all options before giving the answer.<|im_end|>
+
+        <|im_start|>user
+        Question: What is the name of this chemical reaction? {inp}
+
+        Choose ONLY from the following options and write your response choice inside <answer>...</answer>:
+        {opts}
+
+        Do not provide final answer different than what it provided in this list. 
+        <|im_end|>
+
+        <|im_start|>assistant
+        <think>"""
+
+    prompts.append(prompt)
+
+def generate_with_retry(prompt, sampling_params, llm, max_retries=1):
+    """
+    Generate a completion for `prompt`, retrying up to `max_retries` times.
+    On each retry, if no <answer>…</answer> tag was found in the previous
+    completion, we feed back prompt + last_completion + "\n<answer>".
+    Returns the raw text of the first well‐formed completion (or the last attempt).
+    """
+    last_text = ""
+    
+    result  = llm.generate([prompt], sampling_params)
+    outputs = result[0].outputs
+    last_text = outputs[0].text
+    
+    if extract_answer(last_text) is not None:
+        return last_text
+    
+    for attempt in range(1, max_retries+1):
+        print(f"Retry #{attempt}: feeding back previous output + <answer>…")
+        
+        to_send = prompt + last_text + "\n<answer>"
+        
+        result  = llm.generate([to_send], sampling_params)
+        outputs = result[0].outputs
+        last_text = outputs[0].text
+        
+        if extract_answer(last_text) is not None:
+            return last_text
+
+    return last_text
+
+classes_lc = [c.lower() for c in classes]
+
+first_results = llm.generate(prompts, sampling_params)
+
+completions = [res.outputs[0].text for res in first_results]
+
+needs_retry = [
+    i for i, text in enumerate(completions)
+    if extract_answer(text) is None
+]
+
+if needs_retry:
+    retry_prompts = [
+        prompts[i] + completions[i] + "\n<answer>"
+        for i in needs_retry
+    ]
+
+    print(f"Retrying {len(needs_retry)} examples: {needs_retry}")
+    retry_results = llm.generate(retry_prompts, sampling_params)
+
+    for idx, res in zip(needs_retry, retry_results):
+        old_text = completions[idx]
+        new_text = res.outputs[0].text
+
+        new_text = old_text + new_text
+
+        print(f"\nExample #{idx} -- before vs. after:")
+        print("-" * 40)
+        print("OLD completion:\n", old_text)
+        print("\nNEW completion:\n", new_text)
+
+        if extract_answer(new_text) is not None:
+            print(f"Replacing completion for example #{idx} with retry result")
+            print(f"The new completion becomes:\n{new_text}")
+            completions[idx] = new_text
+        else:
+            print(f"Retrying for example #{idx} still has no <answer> tag; keeping old completion")
+
+
+records = []
+correct = 0
+for i, (ex, comp) in enumerate(zip(test_data, completions), start=1):
+    gold = ex["answer"].strip().lower()
+    pred = extract_answer(comp) or ""
+    hit  = gold in pred.lower()
+    if hit:
+        print(f"\nExample #{i}")
+        print("Gold class:   ", ex["answer"].strip().lower())
+        print("Full completion:\n" + comp)
+        print("-" * 80)
+        correct += 1
+        records.append({
+            "example_idx":      i,
+            "gold_answer":      gold,
+            "predicted_answer": pred,
+            "full_completion":  comp
+        })
+
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/naming_2_correct_completions_think_retry_pt.csv", index=False)
+
+acc = 100 * correct / len(test_data)
+print(f"\nFinal Any-of-5 Accuracy: {acc:.2f}% ({correct}/{len(test_data)})")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(acc, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/naming_2_metrics_think_retry_pt.csv", index=False)
+

--- a/evaluation/benchmarking_naming-2-retry.py
+++ b/evaluation/benchmarking_naming-2-retry.py
@@ -1,46 +1,65 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
+import re
+
 import pandas as pd
+from rdkit import Chem
 from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/reaction_class_prompts_600k.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 
 test_df = test_df.drop(columns=["Unnamed: 0", "REACTION"])
 
-test_df = test_df.rename(columns={
-    "REACTION_PROMPT": "input",
-    "CLASS":           "answer"
-})
+test_df = test_df.rename(columns={"REACTION_PROMPT": "input", "CLASS": "answer"})
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-# llm = LLM(model="/data/share/jgoumaz_grpo_models/checkpoints/rxn_naming_409465/checkpoint-200/")  
+# llm = LLM(model="/data/share/jgoumaz_grpo_models/checkpoints/rxn_naming_409465/checkpoint-200/")
 # llm = LLM(model="Qwen/Qwen2.5-3B", trust_remote_code=True)
-llm = LLM(model="/data/share/qwen_pretranined_v6")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/qwen_pretranined_v6")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
 
 def extract_answer(text):
-    m = re.search(r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL|re.IGNORECASE)
+    m = re.search(r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL | re.IGNORECASE)
     if m:
         return m.group(1).strip()
     m2 = re.search(r"([A-Za-z \-]+?)\s*</answer>", text, re.IGNORECASE)
     return m2.group(1).strip() if m2 else None
+
 
 classes = [
     "Acylation",
@@ -92,6 +111,7 @@ for ex in test_data:
 
     prompts.append(prompt)
 
+
 def generate_with_retry(prompt, sampling_params, llm, max_retries=1):
     """
     Generate a completion for `prompt`, retrying up to `max_retries` times.
@@ -100,27 +120,28 @@ def generate_with_retry(prompt, sampling_params, llm, max_retries=1):
     Returns the raw text of the first well‐formed completion (or the last attempt).
     """
     last_text = ""
-    
-    result  = llm.generate([prompt], sampling_params)
+
+    result = llm.generate([prompt], sampling_params)
     outputs = result[0].outputs
     last_text = outputs[0].text
-    
+
     if extract_answer(last_text) is not None:
         return last_text
-    
-    for attempt in range(1, max_retries+1):
+
+    for attempt in range(1, max_retries + 1):
         print(f"Retry #{attempt}: feeding back previous output + <answer>…")
-        
+
         to_send = prompt + last_text + "\n<answer>"
-        
-        result  = llm.generate([to_send], sampling_params)
+
+        result = llm.generate([to_send], sampling_params)
         outputs = result[0].outputs
         last_text = outputs[0].text
-        
+
         if extract_answer(last_text) is not None:
             return last_text
 
     return last_text
+
 
 classes_lc = [c.lower() for c in classes]
 
@@ -128,16 +149,10 @@ first_results = llm.generate(prompts, sampling_params)
 
 completions = [res.outputs[0].text for res in first_results]
 
-needs_retry = [
-    i for i, text in enumerate(completions)
-    if extract_answer(text) is None
-]
+needs_retry = [i for i, text in enumerate(completions) if extract_answer(text) is None]
 
 if needs_retry:
-    retry_prompts = [
-        prompts[i] + completions[i] + "\n<answer>"
-        for i in needs_retry
-    ]
+    retry_prompts = [prompts[i] + completions[i] + "\n<answer>" for i in needs_retry]
 
     print(f"Retrying {len(needs_retry)} examples: {needs_retry}")
     retry_results = llm.generate(retry_prompts, sampling_params)
@@ -166,32 +181,24 @@ correct = 0
 for i, (ex, comp) in enumerate(zip(test_data, completions), start=1):
     gold = ex["answer"].strip().lower()
     pred = extract_answer(comp) or ""
-    hit  = gold in pred.lower()
+    hit = gold in pred.lower()
     if hit:
         print(f"\nExample #{i}")
         print("Gold class:   ", ex["answer"].strip().lower())
         print("Full completion:\n" + comp)
         print("-" * 80)
         correct += 1
-        records.append({
-            "example_idx":      i,
-            "gold_answer":      gold,
-            "predicted_answer": pred,
-            "full_completion":  comp
-        })
+        records.append({"example_idx": i, "gold_answer": gold, "predicted_answer": pred, "full_completion": comp})
 
 
 out_df = pd.DataFrame(records)
-out_df.to_csv("/data/david/benchmark_save_completion_runs/naming_2_correct_completions_think_retry_pt.csv", index=False)
+out_df.to_csv(
+    "/data/david/benchmark_save_completion_runs/naming_2_correct_completions_think_retry_pt.csv", index=False
+)
 
 acc = 100 * correct / len(test_data)
 print(f"\nFinal Any-of-5 Accuracy: {acc:.2f}% ({correct}/{len(test_data)})")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(acc, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(acc, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/naming_2_metrics_think_retry_pt.csv", index=False)
-

--- a/evaluation/benchmarking_naming-2.py
+++ b/evaluation/benchmarking_naming-2.py
@@ -1,44 +1,63 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
+import re
+
 import pandas as pd
+from rdkit import Chem
 from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/reaction_class_prompts_600k.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 
 test_df = test_df.drop(columns=["Unnamed: 0", "REACTION"])
 
-test_df = test_df.rename(columns={
-    "REACTION_PROMPT": "input",
-    "CLASS":           "answer"
-})
+test_df = test_df.rename(columns={"REACTION_PROMPT": "input", "CLASS": "answer"})
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-llm = LLM(model="/data/share/sft_hf_3/")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/sft_hf_3/")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
 
 def extract_answer(text):
-    m = re.search(r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL|re.IGNORECASE)
+    m = re.search(r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL | re.IGNORECASE)
     if m:
         return m.group(1).strip()
     m2 = re.search(r"([A-Za-z \-]+?)\s*</answer>", text, re.IGNORECASE)
     return m2.group(1).strip() if m2 else None
+
 
 classes = [
     "Acylation",
@@ -86,7 +105,7 @@ records = []
 
 for idx, (ex, out) in enumerate(zip(test_data, outputs), 1):
     gold = ex["answer"].strip().lower()
-    hit  = False
+    hit = False
 
     print(f"\n--- Example #{idx} ---")
     print("Question:", ex["input"])
@@ -94,8 +113,8 @@ for idx, (ex, out) in enumerate(zip(test_data, outputs), 1):
     print()
 
     for j, sample in enumerate(out.outputs, 1):
-        comp   = sample.text
-        pred   = extract_answer(comp)
+        comp = sample.text
+        pred = extract_answer(comp)
         if pred:
             ok = gold.lower() in pred.lower()
         else:
@@ -109,13 +128,10 @@ for idx, (ex, out) in enumerate(zip(test_data, outputs), 1):
         if ok:
             hit = True
             correct += 1
-            records.append({
-                "example_idx":      idx,
-                "gold_answer":      gold,
-                "predicted_answer": pred,
-                "full_completion":  comp
-            })
-            break 
+            records.append(
+                {"example_idx": idx, "gold_answer": gold, "predicted_answer": pred, "full_completion": comp}
+            )
+            break
 
     print("Any-of-5 correct overall?", "OK" if hit else "WRONG")
 
@@ -125,11 +141,6 @@ out_df.to_csv("/data/david/benchmark_save_completion_runs/naming_2_correct_compl
 acc = 100 * correct / len(test_data)
 print(f"\nFinal Any-of-5 Accuracy: {acc:.2f}% ({correct}/{len(test_data)})")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(acc, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(acc, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/naming_2_metrics_think.csv", index=False)
-

--- a/evaluation/benchmarking_naming-2.py
+++ b/evaluation/benchmarking_naming-2.py
@@ -1,0 +1,135 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+
+df = pd.read_csv("/data/david/final_tasks_prompts/reaction_class_prompts_600k.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+
+test_df = test_df.drop(columns=["Unnamed: 0", "REACTION"])
+
+test_df = test_df.rename(columns={
+    "REACTION_PROMPT": "input",
+    "CLASS":           "answer"
+})
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+llm = LLM(model="/data/share/sft_hf_3/")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+def extract_answer(text):
+    m = re.search(r"<answer>\s*(.*?)\s*</answer>", text, re.DOTALL|re.IGNORECASE)
+    if m:
+        return m.group(1).strip()
+    m2 = re.search(r"([A-Za-z \-]+?)\s*</answer>", text, re.IGNORECASE)
+    return m2.group(1).strip() if m2 else None
+
+classes = [
+    "Acylation",
+    "Aromatic Heterocycle Formation",
+    "C-C Coupling",
+    "Deprotection",
+    "Functional Group Addition",
+    "Functional Group Interconversion",
+    "Heteroatom Alkylation and Arylation",
+    "Miscellaneous",
+    "Protection",
+    "Reduction",
+]
+
+
+prompts = []
+for ex in test_data:
+    inp = ex["input"].replace("<answer>", "")
+    opts = "\n".join(f"- {cls}" for cls in classes)
+
+    prompt = (
+        "<|im_start|>assistant\n"
+        "You are a useful Chemistry assistant.\n"
+        "Think about your choice and output your reasoning within <think> ... </think> tags.\n"
+        "Make sure to put your final choice inside <answer>…</answer>.\n"
+        "<|im_end|>\n"
+        "<|im_start|>user\n"
+        f"Question: What is the name of this chemical reaction?\n{inp}\n"
+        "Choose **only** from the following list:\n"
+        f"{opts}\n"
+        "<|im_end|>\n"
+        "<|im_start|>assistant\n"
+        "<think>"
+    )
+
+    prompts.append(prompt)
+
+outputs = llm.generate(prompts, sampling_params)
+
+
+classes_lc = [c.lower() for c in classes]
+
+correct = 0
+records = []
+
+for idx, (ex, out) in enumerate(zip(test_data, outputs), 1):
+    gold = ex["answer"].strip().lower()
+    hit  = False
+
+    print(f"\n--- Example #{idx} ---")
+    print("Question:", ex["input"])
+    print("Gold class:", gold)
+    print()
+
+    for j, sample in enumerate(out.outputs, 1):
+        comp   = sample.text
+        pred   = extract_answer(comp)
+        if pred:
+            ok = gold.lower() in pred.lower()
+        else:
+            ok = False
+
+        print(f"--- Sample {j} ---")
+        print(f"Extracted completion:{comp}")
+        print(f"Extracted <answer>: {pred!r}")
+        print(f"Count this sample as correct? {'OK' if ok else 'WRONG'}\n")
+
+        if ok:
+            hit = True
+            correct += 1
+            records.append({
+                "example_idx":      idx,
+                "gold_answer":      gold,
+                "predicted_answer": pred,
+                "full_completion":  comp
+            })
+            break 
+
+    print("Any-of-5 correct overall?", "OK" if hit else "WRONG")
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/naming_2_correct_completions_think.csv", index=False)
+
+acc = 100 * correct / len(test_data)
+print(f"\nFinal Any-of-5 Accuracy: {acc:.2f}% ({correct}/{len(test_data)})")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(acc, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/naming_2_metrics_think.csv", index=False)
+

--- a/evaluation/benchmarking_replacement-2-retry.py
+++ b/evaluation/benchmarking_replacement-2-retry.py
@@ -1,58 +1,79 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
-import pandas as pd
-from sklearn.model_selection import train_test_split
+import re
+
 import numpy as np
+import pandas as pd
+from rdkit import Chem
+from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/mcqa_modified_reactions_1M_prompts.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 print(test_df.columns)
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-# llm = LLM(model="/data/share/sft_hf_3/")  
-llm = LLM(model="/data/share/qwen_pretranined_v6")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+# llm = LLM(model="/data/share/sft_hf_3/")
+llm = LLM(model="/data/share/qwen_pretranined_v6")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
 
 def extract_answer(text):
     """Extract answer letters from <answer> tags, handling multiple answers"""
-    match = re.search(r'\s*(.*?)\s*</answer>', text, re.IGNORECASE)
+    match = re.search(r"\s*(.*?)\s*</answer>", text, re.IGNORECASE)
     if not match:
         return None
 
     content = match.group(1).upper()
-    letters = re.findall(r'\b[A-Z]\b', content) 
+    letters = re.findall(r"\b[A-Z]\b", content)
     return sorted(letters)
 
 
-letters = ["A","B","C","D"]
+letters = ["A", "B", "C", "D"]
 
 
-prompts       = []
-gold_letters  = []
+prompts = []
+gold_letters = []
 for ex in test_data:
     true_rx = ex["true_reaction"]
-    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
-    
+    fakes = [ex["fake1"], ex["fake2"], ex["fake3"]]
+
     opts = np.random.permutation([true_rx] + fakes).tolist()
-    
-    gold_letters.append( letters[ opts.index(true_rx) ] )
-    
+
+    gold_letters.append(letters[opts.index(true_rx)])
+
     prompt = (
         "<|im_start|>assistant\You are an expert in chemistry. Think before chosing your answer and output your reasoning within <think> ... </think> tags."
         "When answering the following MCQ question, you must output ONLY the correct letter inside <answer> tags, choose only the right option.<|im_end|>\n<|im_start|>user\Question:"
@@ -65,14 +86,11 @@ for ex in test_data:
     prompts.append(prompt)
 
 first_results = llm.generate(prompts, sampling_params)
-completions   = [res.outputs[0].text for res in first_results]
+completions = [res.outputs[0].text for res in first_results]
 needs_retry = [i for i, txt in enumerate(completions) if extract_answer(txt) is None]
 
 if needs_retry:
-    retry_prompts = [
-        prompts[i] + completions[i] + "\n<answer>"
-        for i in needs_retry
-    ]
+    retry_prompts = [prompts[i] + completions[i] + "\n<answer>" for i in needs_retry]
     print(f"Retrying {len(needs_retry)} examples: {needs_retry}")
     retry_results = llm.generate(retry_prompts, sampling_params)
 
@@ -95,15 +113,10 @@ correct = 0
 records = []
 for i, (gold, comp) in enumerate(zip(gold_letters, completions), start=1):
     pred = extract_answer(comp)
-    hit  = (pred == gold)
+    hit = pred == gold
     if hit:
         correct += 1
-        records.append({
-            "example_idx": i,
-            "gold_letter": gold,
-            "predicted":   pred,
-            "completion":  comp
-        })
+        records.append({"example_idx": i, "gold_letter": gold, "predicted": pred, "completion": comp})
     print(f"Example #{i}: gold={gold} pred={pred} → {'OK' if hit else 'WRONG'}")
 
 acc = 100 * correct / len(completions)
@@ -113,10 +126,6 @@ out_df = pd.DataFrame(records)
 out_df.to_csv("/data/david/benchmark_save_completion_runs/replacement_2_correct_completions_think.csv", index=False)
 print(f"Saved {len(out_df)} correct completions to replacement_2_correct_completions_think.csv")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(acc, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(acc, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/replacement_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_replacement-2-retry.py
+++ b/evaluation/benchmarking_replacement-2-retry.py
@@ -1,0 +1,122 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+df = pd.read_csv("/data/david/final_tasks_prompts/mcqa_modified_reactions_1M_prompts.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+print(test_df.columns)
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+# llm = LLM(model="/data/share/sft_hf_3/")  
+llm = LLM(model="/data/share/qwen_pretranined_v6")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+def extract_answer(text):
+    """Extract answer letters from <answer> tags, handling multiple answers"""
+    match = re.search(r'\s*(.*?)\s*</answer>', text, re.IGNORECASE)
+    if not match:
+        return None
+
+    content = match.group(1).upper()
+    letters = re.findall(r'\b[A-Z]\b', content) 
+    return sorted(letters)
+
+
+letters = ["A","B","C","D"]
+
+
+prompts       = []
+gold_letters  = []
+for ex in test_data:
+    true_rx = ex["true_reaction"]
+    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
+    
+    opts = np.random.permutation([true_rx] + fakes).tolist()
+    
+    gold_letters.append( letters[ opts.index(true_rx) ] )
+    
+    prompt = (
+        "<|im_start|>assistant\You are an expert in chemistry. Think before chosing your answer and output your reasoning within <think> ... </think> tags."
+        "When answering the following MCQ question, you must output ONLY the correct letter inside <answer> tags, choose only the right option.<|im_end|>\n<|im_start|>user\Question:"
+        f"A. {opts[0]}\n"
+        f"B. {opts[1]}\n"
+        f"C. {opts[2]}\n"
+        f"D. {opts[3]}\n"
+        "<|im_end|>\n<|im_start|>assistant\Your answer correct option: <think>"
+    )
+    prompts.append(prompt)
+
+first_results = llm.generate(prompts, sampling_params)
+completions   = [res.outputs[0].text for res in first_results]
+needs_retry = [i for i, txt in enumerate(completions) if extract_answer(txt) is None]
+
+if needs_retry:
+    retry_prompts = [
+        prompts[i] + completions[i] + "\n<answer>"
+        for i in needs_retry
+    ]
+    print(f"Retrying {len(needs_retry)} examples: {needs_retry}")
+    retry_results = llm.generate(retry_prompts, sampling_params)
+
+    for idx, res in zip(needs_retry, retry_results):
+        old = completions[idx]
+        new = res.outputs[0].text
+
+        print(f"\nExample #{idx} – before vs. after")
+        print("OLD:", old)
+        print("NEW:", new)
+
+        if extract_answer(new) is not None:
+            merged = old + new
+            print("Merged retry for index", idx)
+            completions[idx] = merged
+        else:
+            print("Still no tag at index", idx)
+
+correct = 0
+records = []
+for i, (gold, comp) in enumerate(zip(gold_letters, completions), start=1):
+    pred = extract_answer(comp)
+    hit  = (pred == gold)
+    if hit:
+        correct += 1
+        records.append({
+            "example_idx": i,
+            "gold_letter": gold,
+            "predicted":   pred,
+            "completion":  comp
+        })
+    print(f"Example #{i}: gold={gold} pred={pred} → {'OK' if hit else 'WRONG'}")
+
+acc = 100 * correct / len(completions)
+print(f"\nFinal any‐of‐5 accuracy: {acc:.2f}% ({correct}/{len(completions)})")
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/replacement_2_correct_completions_think.csv", index=False)
+print(f"Saved {len(out_df)} correct completions to replacement_2_correct_completions_think.csv")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(acc, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/replacement_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_replacement.py
+++ b/evaluation/benchmarking_replacement.py
@@ -1,0 +1,116 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+df = pd.read_csv("/data/david/final_tasks_prompts/mcqa_modified_reactions_1M_prompts.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+print(test_df.columns)
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+llm = LLM(model="/data/share/sft_hf_3/") 
+# llm = LLM(model="/data/share/qwen_sft_base_hf/")  
+# llm = LLM(model="/data/share/qwen_pretranined_v6")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+def extract_answer(text):
+    """Extract answer letters from <answer> tags, handling multiple answers"""
+    match = re.search(r'\s*(.*?)\s*</answer>', text, re.IGNORECASE)
+    if not match:
+        return None
+    content = match.group(1).upper()
+    letters = re.findall(r'\b[A-Z]\b', content)  
+    return sorted(letters)
+
+
+letters = ["A","B","C","D"]
+
+
+prompts       = []
+gold_letters  = []
+for ex in test_data:
+    true_rx = ex["true_reaction"]
+    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
+    
+    opts = np.random.permutation([true_rx] + fakes).tolist()
+    
+    gold_letters.append( letters[ opts.index(true_rx) ] )
+    
+    prompt = (
+        "<|im_start|>assistant\You are an expert in chemistry. Answer the following MCQ question with ONLY the correct letter(s) inside <answer> tags, choose only the right option.<|im_end|>\n<|im_start|>user\Question:"
+        f"A. {opts[0]}\n"
+        f"B. {opts[1]}\n"
+        f"C. {opts[2]}\n"
+        f"D. {opts[3]}\n"
+        "<|im_end|>\n<|im_start|>assistant\Your answer correct option: <answer>"
+    )
+    prompts.append(prompt)
+
+
+outputs = llm.generate(prompts, sampling_params)
+
+correct = 0
+records = []
+
+for idx, (gold, prompt, out) in enumerate(zip(gold_letters, prompts, outputs), start=1):
+    print(f"\n=== Example #{idx} (gold = {gold}) ===")
+    print("Prompt:")
+    print(prompt)
+    print()
+
+    hit = False
+    for j, sample in enumerate(out.outputs, start=1):
+        text = sample.text.strip()
+        pred_letters = extract_answer(text) 
+        pred = pred_letters[0] if pred_letters else None
+
+        ok = (pred == gold)
+        print(f" Sample {j}:")
+        print("  completion:", text)
+        print("  extracted:", pred_letters, "->", pred)
+        print("  match?", "OK" if ok else "WRONG")
+        
+        if ok:
+            correct += 1
+            hit = True
+            records.append({
+                "example_idx":    idx,
+                "gold_letter":    gold,
+                "predicted":      pred,
+                "completion":     text
+            })
+            break  
+
+    print("Any-of-5 correct overall?", "OK" if hit else "WRONG")
+
+acc = 100 * correct / len(outputs)
+print(f"\nFinal any-of-5 accuracy: {acc:.2f}% ({correct}/{len(outputs)})")
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/replacement_correct_completions_nothink_pretrainedonly.csv", index=False)
+print(f"Saved {len(out_df)} correct completions to replacement_correct_completions_nothink.csv")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(acc, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/replacement_metrics_nothink_pretrainedonly.csv", index=False)

--- a/evaluation/benchmarking_replacement.py
+++ b/evaluation/benchmarking_replacement.py
@@ -1,58 +1,79 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
-import pandas as pd
-from sklearn.model_selection import train_test_split
+import re
+
 import numpy as np
+import pandas as pd
+from rdkit import Chem
+from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/mcqa_modified_reactions_1M_prompts.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 print(test_df.columns)
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-llm = LLM(model="/data/share/sft_hf_3/") 
-# llm = LLM(model="/data/share/qwen_sft_base_hf/")  
-# llm = LLM(model="/data/share/qwen_pretranined_v6")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/sft_hf_3/")
+# llm = LLM(model="/data/share/qwen_sft_base_hf/")
+# llm = LLM(model="/data/share/qwen_pretranined_v6")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
 
 def extract_answer(text):
     """Extract answer letters from <answer> tags, handling multiple answers"""
-    match = re.search(r'\s*(.*?)\s*</answer>', text, re.IGNORECASE)
+    match = re.search(r"\s*(.*?)\s*</answer>", text, re.IGNORECASE)
     if not match:
         return None
     content = match.group(1).upper()
-    letters = re.findall(r'\b[A-Z]\b', content)  
+    letters = re.findall(r"\b[A-Z]\b", content)
     return sorted(letters)
 
 
-letters = ["A","B","C","D"]
+letters = ["A", "B", "C", "D"]
 
 
-prompts       = []
-gold_letters  = []
+prompts = []
+gold_letters = []
 for ex in test_data:
     true_rx = ex["true_reaction"]
-    fakes   = [ex["fake1"], ex["fake2"], ex["fake3"]]
-    
+    fakes = [ex["fake1"], ex["fake2"], ex["fake3"]]
+
     opts = np.random.permutation([true_rx] + fakes).tolist()
-    
-    gold_letters.append( letters[ opts.index(true_rx) ] )
-    
+
+    gold_letters.append(letters[opts.index(true_rx)])
+
     prompt = (
         "<|im_start|>assistant\You are an expert in chemistry. Answer the following MCQ question with ONLY the correct letter(s) inside <answer> tags, choose only the right option.<|im_end|>\n<|im_start|>user\Question:"
         f"A. {opts[0]}\n"
@@ -78,25 +99,20 @@ for idx, (gold, prompt, out) in enumerate(zip(gold_letters, prompts, outputs), s
     hit = False
     for j, sample in enumerate(out.outputs, start=1):
         text = sample.text.strip()
-        pred_letters = extract_answer(text) 
+        pred_letters = extract_answer(text)
         pred = pred_letters[0] if pred_letters else None
 
-        ok = (pred == gold)
+        ok = pred == gold
         print(f" Sample {j}:")
         print("  completion:", text)
         print("  extracted:", pred_letters, "->", pred)
         print("  match?", "OK" if ok else "WRONG")
-        
+
         if ok:
             correct += 1
             hit = True
-            records.append({
-                "example_idx":    idx,
-                "gold_letter":    gold,
-                "predicted":      pred,
-                "completion":     text
-            })
-            break  
+            records.append({"example_idx": idx, "gold_letter": gold, "predicted": pred, "completion": text})
+            break
 
     print("Any-of-5 correct overall?", "OK" if hit else "WRONG")
 
@@ -104,13 +120,14 @@ acc = 100 * correct / len(outputs)
 print(f"\nFinal any-of-5 accuracy: {acc:.2f}% ({correct}/{len(outputs)})")
 
 out_df = pd.DataFrame(records)
-out_df.to_csv("/data/david/benchmark_save_completion_runs/replacement_correct_completions_nothink_pretrainedonly.csv", index=False)
+out_df.to_csv(
+    "/data/david/benchmark_save_completion_runs/replacement_correct_completions_nothink_pretrainedonly.csv",
+    index=False,
+)
 print(f"Saved {len(out_df)} correct completions to replacement_correct_completions_nothink.csv")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(acc, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(acc, 2), "correct": correct, "total": len(test_data)}])
 
-metrics.to_csv("/data/david/benchmark_save_completion_runs/replacement_metrics_nothink_pretrainedonly.csv", index=False)
+metrics.to_csv(
+    "/data/david/benchmark_save_completion_runs/replacement_metrics_nothink_pretrainedonly.csv", index=False
+)

--- a/evaluation/benchmarking_truefalse-2-retry.py
+++ b/evaluation/benchmarking_truefalse-2-retry.py
@@ -1,0 +1,132 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+df = pd.read_csv("/data/david/final_tasks_prompts/is_it_correct_reaction_1M.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+
+print(test_df.columns)
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+llm = LLM(model="/data/share/sft_hf_3/")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+TEMPLATE = """<|im_start|>assistant
+You are a useful Chemistry assistant and will answer whether the reaction is True or False.
+You are allowed to think about the question and you must output your reasoning within <think> ... </think> tags. Your will need to respond with True or False within <answer>True</answer> or <answer>False</answer>.
+<|im_end|>
+
+<|im_start|>user
+Question: Is this chemical reaction correct?
+{reaction}
+
+Make sure to reason about the mechanism in <think> tags.
+<|im_end|>
+
+<|im_start|>assistant
+<think>"""
+
+def extract_answer_tag(text: str):
+
+    """
+    1) Try to pull 'True' or 'False' out of a well-formed <answer>…</answer>.
+    2) Otherwise, grab the last occurrence of true/false/correct/incorrect
+       before </answer> and normalize to 'true'/'false'.
+    """
+    m = re.search(r"<answer>\s*(true|false)\s*</answer>", text, re.IGNORECASE)
+    if m:
+        return m.group(1).lower()
+
+    idx = text.lower().rfind("</answer>")
+    if idx == -1:
+        return None
+
+    snippet = text[:idx]
+    toks = re.findall(r"\b(true|false|correct|incorrect)\b", snippet, re.IGNORECASE)
+    if not toks:
+        return None
+
+    last = toks[-1].lower()
+    if last == "correct":
+        return "true"
+    if last == "incorrect":
+        return "false"
+    return last
+
+for sample in [
+    " The reaction is correct. </answer>",
+    " The reaction is True. </answer>",
+    " False </answer>",
+    "<answer>false</answer>",
+]:
+    print(sample, "->", extract_answer_tag(sample))
+
+
+prompts     = [TEMPLATE.format(reaction=rec["reaction"]) for rec in test_data]
+gold_labels = [str(rec["label"]).strip().lower()    for rec in test_data]
+
+outputs = llm.generate(prompts, sampling_params)
+
+correct = 0
+records = []
+
+for idx, (rec, out, gold) in enumerate(zip(test_data, outputs, gold_labels), 1):
+    print(f"\n=== Example #{idx} ===\nPrompt: {rec['reaction']}\nGold: {gold}\n")
+    hit = False
+
+    for j, sample in enumerate(out.outputs, 1):
+        comp = sample.text            
+        pred = extract_answer_tag(comp)  
+
+        print(f" Sample {j} raw: {comp!r}  -> extracted: {pred!r}")
+
+        if pred == gold:
+            print("Correct!")
+            correct += 1
+            hit = True
+            records.append({
+                "example_idx":   idx,
+                "prompt":        rec["reaction"],
+                "gold_label":    gold,
+                "predicted":     pred,
+                "completion":    comp
+            })
+            break
+        else:
+            print("Incorrect")
+
+    print("Any-of-5 correct?", "OK" if hit else "WRONG")
+
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/true_false_2_correct_completions_think.csv", index=False)
+print(f"\nSaved {len(records)} correct completions to true_false_2_correct_completions_think.csv")
+
+accuracy = 100 * correct / len(test_data)
+print(f"\nFinal any-of-5 accuracy: {accuracy:.2f}% ({correct}/{len(test_data)})")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(accuracy, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/true_false_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_truefalse-2-retry.py
+++ b/evaluation/benchmarking_truefalse-2-retry.py
@@ -1,33 +1,53 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
-import pandas as pd
-from sklearn.model_selection import train_test_split
+import re
+
 import numpy as np
+import pandas as pd
+from rdkit import Chem
+from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/is_it_correct_reaction_1M.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 
 print(test_df.columns)
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-llm = LLM(model="/data/share/sft_hf_3/")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/sft_hf_3/")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
 
 TEMPLATE = """<|im_start|>assistant
 You are a useful Chemistry assistant and will answer whether the reaction is True or False.
@@ -44,8 +64,8 @@ Make sure to reason about the mechanism in <think> tags.
 <|im_start|>assistant
 <think>"""
 
-def extract_answer_tag(text: str):
 
+def extract_answer_tag(text: str):
     """
     1) Try to pull 'True' or 'False' out of a well-formed <answer>…</answer>.
     2) Otherwise, grab the last occurrence of true/false/correct/incorrect
@@ -71,6 +91,7 @@ def extract_answer_tag(text: str):
         return "false"
     return last
 
+
 for sample in [
     " The reaction is correct. </answer>",
     " The reaction is True. </answer>",
@@ -80,8 +101,8 @@ for sample in [
     print(sample, "->", extract_answer_tag(sample))
 
 
-prompts     = [TEMPLATE.format(reaction=rec["reaction"]) for rec in test_data]
-gold_labels = [str(rec["label"]).strip().lower()    for rec in test_data]
+prompts = [TEMPLATE.format(reaction=rec["reaction"]) for rec in test_data]
+gold_labels = [str(rec["label"]).strip().lower() for rec in test_data]
 
 outputs = llm.generate(prompts, sampling_params)
 
@@ -93,8 +114,8 @@ for idx, (rec, out, gold) in enumerate(zip(test_data, outputs, gold_labels), 1):
     hit = False
 
     for j, sample in enumerate(out.outputs, 1):
-        comp = sample.text            
-        pred = extract_answer_tag(comp)  
+        comp = sample.text
+        pred = extract_answer_tag(comp)
 
         print(f" Sample {j} raw: {comp!r}  -> extracted: {pred!r}")
 
@@ -102,13 +123,15 @@ for idx, (rec, out, gold) in enumerate(zip(test_data, outputs, gold_labels), 1):
             print("Correct!")
             correct += 1
             hit = True
-            records.append({
-                "example_idx":   idx,
-                "prompt":        rec["reaction"],
-                "gold_label":    gold,
-                "predicted":     pred,
-                "completion":    comp
-            })
+            records.append(
+                {
+                    "example_idx": idx,
+                    "prompt": rec["reaction"],
+                    "gold_label": gold,
+                    "predicted": pred,
+                    "completion": comp,
+                }
+            )
             break
         else:
             print("Incorrect")
@@ -123,10 +146,6 @@ print(f"\nSaved {len(records)} correct completions to true_false_2_correct_compl
 accuracy = 100 * correct / len(test_data)
 print(f"\nFinal any-of-5 accuracy: {accuracy:.2f}% ({correct}/{len(test_data)})")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(accuracy, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(accuracy, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/true_false_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_truefalse-2.py
+++ b/evaluation/benchmarking_truefalse-2.py
@@ -1,33 +1,53 @@
-from vllm import LLM, SamplingParams
-from rdkit import Chem
-import re
 import pickle
-import pandas as pd
-from sklearn.model_selection import train_test_split
+import re
+
 import numpy as np
+import pandas as pd
+from rdkit import Chem
+from sklearn.model_selection import train_test_split
+
+from vllm import LLM, SamplingParams
 
 df = pd.read_csv("/data/david/final_tasks_prompts/is_it_correct_reaction_1M.csv")
 
 df = df.iloc[10_000:].reset_index(drop=True)
 
-train_df, test_df = train_test_split(
-    df,
-    test_size=3000,     
-    random_state=42,   
-    shuffle=True
-)
+train_df, test_df = train_test_split(df, test_size=3000, random_state=42, shuffle=True)
 
 print(test_df.columns)
 
-test_data  = test_df.to_dict(orient="records")
+test_data = test_df.to_dict(orient="records")
 
 all_keys = set().union(*(rec.keys() for rec in test_data))
 print(all_keys)
 
 # Load vLLM model
-llm = LLM(model="/data/share/sft_hf_3/")  
-sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
-#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+llm = LLM(model="/data/share/sft_hf_3/")
+sampling_params = SamplingParams(
+    n=1,
+    presence_penalty=0.0,
+    frequency_penalty=0.0,
+    repetition_penalty=1.00,
+    temperature=0.8,
+    top_p=0.80,
+    top_k=20,
+    min_p=0.0,
+    seed=None,
+    stop=[],
+    stop_token_ids=[151643, 151644, 151645],
+    bad_words=[],
+    include_stop_str_in_output=False,
+    ignore_eos=False,
+    max_tokens=4096,
+    min_tokens=0,
+    logprobs=None,
+    prompt_logprobs=None,
+    skip_special_tokens=True,
+    spaces_between_special_tokens=True,
+    truncate_prompt_tokens=None,
+    guided_decoding=None,
+)
+# sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
 
 TEMPLATE = """<|im_start|>assistant
 You are a useful Chemistry assistant and will answer whether the reaction is True or False.
@@ -44,8 +64,8 @@ Make sure to reason about the mechanism in <think> tags.
 <|im_start|>assistant
 <think>"""
 
-def extract_answer_tag(text: str):
 
+def extract_answer_tag(text: str):
     """
     1) Try to pull 'True' or 'False' out of a well-formed <answer>…</answer>.
     2) Otherwise, grab the last occurrence of true/false/correct/incorrect
@@ -70,6 +90,7 @@ def extract_answer_tag(text: str):
         return "false"
     return last
 
+
 for sample in [
     " The reaction is correct. </answer>",
     " The reaction is True. </answer>",
@@ -79,8 +100,8 @@ for sample in [
     print(sample, "->", extract_answer_tag(sample))
 
 
-prompts     = [TEMPLATE.format(reaction=rec["reaction"]) for rec in test_data]
-gold_labels = [str(rec["label"]).strip().lower()    for rec in test_data]
+prompts = [TEMPLATE.format(reaction=rec["reaction"]) for rec in test_data]
+gold_labels = [str(rec["label"]).strip().lower() for rec in test_data]
 
 
 outputs = llm.generate(prompts, sampling_params)
@@ -94,20 +115,22 @@ for idx, (rec, out, gold) in enumerate(zip(test_data, outputs, gold_labels), 1):
     hit = False
 
     for j, sample in enumerate(out.outputs, 1):
-        comp = sample.text           
-        pred = extract_answer_tag(comp) 
+        comp = sample.text
+        pred = extract_answer_tag(comp)
         print(f" Sample {j} raw: {comp!r} -> extracted: {pred!r}")
         if pred == gold:
             print("Correct!")
             correct += 1
             hit = True
-            records.append({
-                "example_idx":   idx,
-                "prompt":        rec["reaction"],
-                "gold_label":    gold,
-                "predicted":     pred,
-                "completion":    comp
-            })
+            records.append(
+                {
+                    "example_idx": idx,
+                    "prompt": rec["reaction"],
+                    "gold_label": gold,
+                    "predicted": pred,
+                    "completion": comp,
+                }
+            )
             break
         else:
             print("Incorrect")
@@ -122,10 +145,6 @@ print(f"\nSaved {len(records)} correct completions to true_false_2_correct_compl
 accuracy = 100 * correct / len(test_data)
 print(f"\nFinal any-of-5 accuracy: {accuracy:.2f}% ({correct}/{len(test_data)})")
 
-metrics = pd.DataFrame([{
-    "accuracy_pct":   round(accuracy, 2),
-    "correct":        correct,
-    "total":          len(test_data)
-}])
+metrics = pd.DataFrame([{"accuracy_pct": round(accuracy, 2), "correct": correct, "total": len(test_data)}])
 
 metrics.to_csv("/data/david/benchmark_save_completion_runs/true_false_2_metrics_think.csv", index=False)

--- a/evaluation/benchmarking_truefalse-2.py
+++ b/evaluation/benchmarking_truefalse-2.py
@@ -1,0 +1,131 @@
+from vllm import LLM, SamplingParams
+from rdkit import Chem
+import re
+import pickle
+import pandas as pd
+from sklearn.model_selection import train_test_split
+import numpy as np
+
+df = pd.read_csv("/data/david/final_tasks_prompts/is_it_correct_reaction_1M.csv")
+
+df = df.iloc[10_000:].reset_index(drop=True)
+
+train_df, test_df = train_test_split(
+    df,
+    test_size=3000,     
+    random_state=42,   
+    shuffle=True
+)
+
+print(test_df.columns)
+
+test_data  = test_df.to_dict(orient="records")
+
+all_keys = set().union(*(rec.keys() for rec in test_data))
+print(all_keys)
+
+# Load vLLM model
+llm = LLM(model="/data/share/sft_hf_3/")  
+sampling_params = SamplingParams(n=1, presence_penalty=0.0, frequency_penalty=0.0, repetition_penalty=1.00, temperature=0.8, top_p=0.80, top_k=20, min_p=0.0, seed=None, stop=[], stop_token_ids=[151643, 151644, 151645], bad_words=[], include_stop_str_in_output=False, ignore_eos=False, max_tokens=4096, min_tokens=0, logprobs=None, prompt_logprobs=None, skip_special_tokens=True, spaces_between_special_tokens=True, truncate_prompt_tokens=None, guided_decoding=None)
+#sampling_params = SamplingParams(n=5, max_tokens=4096, stop_token_ids=[151643, 151644, 151645])
+
+TEMPLATE = """<|im_start|>assistant
+You are a useful Chemistry assistant and will answer whether the reaction is True or False.
+You are allowed to think about the question and you must output your reasoning within <think> ... </think> tags. Your will need to respond with True or False within <answer>True</answer> or <answer>False</answer>.
+<|im_end|>
+
+<|im_start|>user
+Question: Is this chemical reaction correct?
+{reaction}
+
+Make sure to reason about the mechanism in <think> tags.
+<|im_end|>
+
+<|im_start|>assistant
+<think>"""
+
+def extract_answer_tag(text: str):
+
+    """
+    1) Try to pull 'True' or 'False' out of a well-formed <answer>…</answer>.
+    2) Otherwise, grab the last occurrence of true/false/correct/incorrect
+       before </answer> and normalize to 'true'/'false'.
+    """
+    m = re.search(r"<answer>\s*(true|false)\s*</answer>", text, re.IGNORECASE)
+    if m:
+        return m.group(1).lower()
+    idx = text.lower().rfind("</answer>")
+    if idx == -1:
+        return None
+
+    snippet = text[:idx]
+    toks = re.findall(r"\b(true|false|correct|incorrect)\b", snippet, re.IGNORECASE)
+    if not toks:
+        return None
+
+    last = toks[-1].lower()
+    if last == "correct":
+        return "true"
+    if last == "incorrect":
+        return "false"
+    return last
+
+for sample in [
+    " The reaction is correct. </answer>",
+    " The reaction is True. </answer>",
+    " False </answer>",
+    "<answer>false</answer>",
+]:
+    print(sample, "->", extract_answer_tag(sample))
+
+
+prompts     = [TEMPLATE.format(reaction=rec["reaction"]) for rec in test_data]
+gold_labels = [str(rec["label"]).strip().lower()    for rec in test_data]
+
+
+outputs = llm.generate(prompts, sampling_params)
+
+
+correct = 0
+records = []
+
+for idx, (rec, out, gold) in enumerate(zip(test_data, outputs, gold_labels), 1):
+    print(f"\n=== Example #{idx} ===\nPrompt: {rec['reaction']}\nGold: {gold}\n")
+    hit = False
+
+    for j, sample in enumerate(out.outputs, 1):
+        comp = sample.text           
+        pred = extract_answer_tag(comp) 
+        print(f" Sample {j} raw: {comp!r} -> extracted: {pred!r}")
+        if pred == gold:
+            print("Correct!")
+            correct += 1
+            hit = True
+            records.append({
+                "example_idx":   idx,
+                "prompt":        rec["reaction"],
+                "gold_label":    gold,
+                "predicted":     pred,
+                "completion":    comp
+            })
+            break
+        else:
+            print("Incorrect")
+
+    print("Any-of-5 correct?", "OK" if hit else "WRONG")
+
+
+out_df = pd.DataFrame(records)
+out_df.to_csv("/data/david/benchmark_save_completion_runs/true_false_2_correct_completions_think.csv", index=False)
+print(f"\nSaved {len(records)} correct completions to true_false_2_correct_completions_think.csv")
+
+accuracy = 100 * correct / len(test_data)
+print(f"\nFinal any-of-5 accuracy: {accuracy:.2f}% ({correct}/{len(test_data)})")
+
+metrics = pd.DataFrame([{
+    "accuracy_pct":   round(accuracy, 2),
+    "correct":        correct,
+    "total":          len(test_data)
+}])
+
+metrics.to_csv("/data/david/benchmark_save_completion_runs/true_false_2_metrics_think.csv", index=False)

--- a/src/open_r1/diagnostic/smiles_competence.py
+++ b/src/open_r1/diagnostic/smiles_competence.py
@@ -1,29 +1,19 @@
-import argparse
-import json
 import os
 import random
 import re
-import time
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
 
-from pydantic import BaseModel
-
-DEFAULT_DATA_PATH = "${MIST_DATA_DIR}/CRLLM-PubChem-compounds1M.csv"
-DEFAULT_OUTPUT_DIR = "${MIST_OUTPUT_DIR}/scs"
+from vllm import LLM, SamplingParams
 
 
-def load_llm(model, max_num_seqs, max_model_len, tensor_parallel_size, dtype):
-    from vllm import LLM, SamplingParams
-
+def load_llm(model):
     llm = LLM(
         model=model,
-        max_num_seqs=max_num_seqs,
-        max_model_len=max_model_len,
-        tensor_parallel_size=tensor_parallel_size,
-        dtype=dtype,
+        max_num_seqs=5,
+        max_model_len=256,
+        tensor_parallel_size=4,
     )
     params = SamplingParams(
         temperature=0.0,
@@ -34,36 +24,49 @@ def load_llm(model, max_num_seqs, max_model_len, tensor_parallel_size, dtype):
 
 
 def prompt_template(smiles):
-    return f"The molecule represented with the SMILES [BEGIN_SMILES] {smiles} [END_SMILES]"
+    tmp = f"""The molecule represented with the SMILES [BEGIN_SMILES] {smiles} [END_SMILES]"""
+    return tmp
 
 
-def corrupt_smi(smiles, rng, corruption_rate=0.2):
-    """Randomly delete grammar characters from a SMILES string."""
+def corrupt_smi(smiles, corruption_rate=0.2):
+    """
+    Randomly deletes grammar elements from a SMILES string.
+
+    Args:
+        smiles (str): The original SMILES string.
+        corruption_rate (float): Proportion of grammar elements to remove (0 to 1).
+
+    Returns:
+        str: The corrupted SMILES string.
+    """
+    # Define grammar elements to target
     grammar_elements = set("()[]0123456789")
-    indices = [i for i, char in enumerate(smiles) if char in grammar_elements]
+    indices = [i for i, c in enumerate(smiles) if c in grammar_elements]
 
+    # Determine how many to remove
     n_remove = max(1, int(len(indices) * corruption_rate)) if indices else 0
     if n_remove == 0:
-        return smiles
+        return smiles  # Nothing to remove
 
-    remove_indices = set(rng.sample(indices, n_remove))
-    return "".join(char for i, char in enumerate(smiles) if i not in remove_indices)
+    # Randomly select indices to remove
+    remove_indices = set(random.sample(indices, n_remove))
+
+    # Build new string
+    corrupted = "".join(c for i, c in enumerate(smiles) if i not in remove_indices)
+    return corrupted
 
 
-def load_dataset(data_path, num_rows, corruption_rate, seed):
-    df = pd.read_csv(data_path, nrows=num_rows)
-
-    required_columns = {"SMILES", "SMILES_variant1"}
-    missing = required_columns.difference(df.columns)
-    if missing:
-        raise ValueError(f"Missing required columns in {data_path}: {', '.join(sorted(missing))}")
-
-    rng = random.Random(seed)
+def load_dataset(data_dir):
+    df = pd.read_csv(data_dir, nrows=10000)
     df["prompt_canon"] = df["SMILES"].apply(prompt_template)
     df["prompt_random"] = df["SMILES_variant1"].apply(prompt_template)
-    df["corrupt"] = df["SMILES"].apply(lambda smiles: corrupt_smi(smiles, rng, corruption_rate=corruption_rate))
+
+    df["corrupt"] = df["SMILES"].apply(corrupt_smi)
     df["prompt_corrupt"] = df["corrupt"].apply(prompt_template)
     return df
+
+
+from pydantic import BaseModel
 
 
 class LogprobStat(BaseModel):
@@ -73,276 +76,84 @@ class LogprobStat(BaseModel):
     smiles: str
 
 
-def _find_smiles_token_span(prompt_text, token_ids, logprobs_list):
-    """Find the token index span corresponding to the SMILES between the
-    [BEGIN_SMILES] and [END_SMILES] markers.  Falls back to a heuristic trim
-    of the first 12 and last 5 tokens when markers are not decodable."""
-    # Decode each token to locate the boundary markers
-    decoded = []
-    for idx, (lp, tid) in enumerate(zip(logprobs_list, token_ids)):
-        if lp is None:
-            decoded.append((idx, ""))
-            continue
-        entry = lp.get(tid)
-        decoded.append((idx, entry.decoded_token if entry else ""))
+def run_column(col, llm, params, data):
+    def process_out(out):
+        try:
+            smiles_tokens = out.prompt_token_ids[12:][:-5]
+            lps = out.prompt_logprobs[12:][:-5]
 
-    joined = "".join(t for _, t in decoded)
-    # Find markers in the concatenated decoded text
-    begin_tag = "[BEGIN_SMILES]"
-    end_tag = "[END_SMILES]"
-    begin_pos = joined.find(begin_tag)
-    end_pos = joined.find(end_tag)
+            # vllm gives you logprobs for your token, and for rank1 token
+            smi_lps = [v[x].logprob for v, x in zip(lps, smiles_tokens)]
+            smi_rank = [v[x].rank for v, x in zip(lps, smiles_tokens)]
 
-    if begin_pos == -1 or end_pos == -1:
-        # Fallback: assume template has ~12 prefix tokens and ~5 suffix tokens
-        return 12, len(token_ids) - 5
+            smiles = "".join([v[x].decoded_token for v, x in zip(lps, smiles_tokens)])
+            smiles = re.sub("Ġ", "", "".join(smiles))
 
-    # Walk through decoded tokens to find the indices that bracket the SMILES
-    running = 0
-    start_idx = None
-    end_idx = None
-    for idx, tok_text in decoded:
-        prev_running = running
-        running += len(tok_text)
-        # The SMILES starts after the space following [BEGIN_SMILES]
-        if start_idx is None and running > begin_pos + len(begin_tag):
-            start_idx = idx
-        # The SMILES ends where [END_SMILES] begins
-        if end_idx is None and running >= end_pos:
-            end_idx = idx
-            break
+            return LogprobStat(
+                mean_logprob=np.mean(smi_lps), mean_rank=np.mean(smi_rank), n_tokens=len(smiles_tokens), smiles=smiles
+            ).__dict__
 
-    if start_idx is None or end_idx is None:
-        return 12, len(token_ids) - 5
+        except:
+            return LogprobStat(mean_logprob=0, mean_rank=0, n_tokens=1000, smiles="").__dict__
 
-    return start_idx, end_idx
+    out = llm.generate(data[col], params)
+    lps = [process_out(o) for o in out]
+
+    return pd.DataFrame(lps)
 
 
-def process_generation_output(out):
-    try:
-        start, end = _find_smiles_token_span(out.prompt, out.prompt_token_ids, out.prompt_logprobs)
-        smiles_tokens = out.prompt_token_ids[start:end]
-        logprobs = out.prompt_logprobs[start:end]
+def main(model, data_dir):
+    llm, params = load_llm(model)
+    data = load_dataset(data_dir)
 
-        token_logprobs = [values[token_id].logprob for values, token_id in zip(logprobs, smiles_tokens)]
-        token_ranks = [values[token_id].rank for values, token_id in zip(logprobs, smiles_tokens)]
-        smiles = "".join(values[token_id].decoded_token for values, token_id in zip(logprobs, smiles_tokens))
-        smiles = re.sub("Ġ", "", smiles)
+    out_canon = run_column("prompt_canon", llm, params, data)
+    out_random = run_column("prompt_random", llm, params, data)
+    out_corrupt = run_column("prompt_corrupt", llm, params, data)
 
-        return LogprobStat(
-            mean_logprob=float(np.mean(token_logprobs)),
-            mean_rank=float(np.mean(token_ranks)),
-            n_tokens=len(smiles_tokens),
-            smiles=smiles,
-        ).model_dump()
-    except Exception as exc:
-        import sys
+    write_dir = os.path.dirname(data_dir)
 
-        print(f"WARNING: process_generation_output failed: {exc}", file=sys.stderr)
-        return LogprobStat(
-            mean_logprob=float("nan"),
-            mean_rank=float("nan"),
-            n_tokens=0,
-            smiles="",
-        ).model_dump()
+    out_canon.to_csv(os.path.join(write_dir, "lps_canonical.csv"), index=False)
+    out_random.to_csv(os.path.join(write_dir, "lps_random.csv"), index=False)
+    out_corrupt.to_csv(os.path.join(write_dir, "lps_corrup.csv"), index=False)
 
+    # Report some metrics here (e.g. avg difference, diff of averages, relative to canon)
+    print("Means:")
+    print("CANON", out_canon[["mean_logprob", "mean_rank"]].mean())
+    print("RANDOM", out_random[["mean_logprob", "mean_rank"]].mean())
+    print("CORRUPT", out_corrupt[["mean_logprob", "mean_rank"]].mean())
+    print("----------")
 
-def run_column(column_name, llm, params, data, batch_size):
-    prompts = data[column_name].tolist()
-    total = len(prompts)
-    rows = []
-    start_time = time.time()
+    from numpy import mean, sqrt, std
 
-    for batch_start in range(0, total, batch_size):
-        batch_end = min(batch_start + batch_size, total)
-        batch_prompts = prompts[batch_start:batch_end]
-        outputs = llm.generate(batch_prompts, params)
-        rows.extend(process_generation_output(output) for output in outputs)
+    # correct if the population S.D. is expected to be equal for the two groups.
+    def cohen_d(x, y):
+        nx = len(x)
+        ny = len(y)
+        dof = nx + ny - 2
+        return (mean(x) - mean(y)) / sqrt(((nx - 1) * std(x, ddof=1) ** 2 + (ny - 1) * std(y, ddof=1) ** 2) / dof)
 
-        elapsed = time.time() - start_time
-        print(
-            f"[{column_name}] processed {batch_end}/{total} prompts "
-            f"(batch_size={batch_size}, elapsed={elapsed:.1f}s)",
-            flush=True,
-        )
+    lp_canon = out_canon["mean_logprob"]
+    rk_canon = out_canon["mean_rank"]
+    lp_corrupt = out_corrupt["mean_logprob"]
+    rk_corrupt = out_corrupt["mean_rank"]
+    lp_sc = cohen_d(lp_canon, lp_corrupt)
+    rk_sc = cohen_d(rk_canon, rk_corrupt)
 
-    return pd.DataFrame(rows)
-
-
-def cohen_d(x, y):
-    std_x = np.std(x, ddof=1)
-    std_y = np.std(y, ddof=1)
-    nx = len(x)
-    ny = len(y)
-    dof = nx + ny - 2
-    pooled = np.sqrt(((nx - 1) * std_x**2 + (ny - 1) * std_y**2) / dof)
-    return (np.mean(x) - np.mean(y)) / pooled
-
-
-def summarize_results(out_canon, out_random, out_corrupt):
-    means = {
-        "canonical": out_canon[["mean_logprob", "mean_rank"]].mean().to_dict(),
-        "randomized": out_random[["mean_logprob", "mean_rank"]].mean().to_dict(),
-        "corrupted": out_corrupt[["mean_logprob", "mean_rank"]].mean().to_dict(),
-    }
-
-    return {
-        "means": means,
-        "scs_logprob": float(cohen_d(out_canon["mean_logprob"], out_corrupt["mean_logprob"])),
-        "scs_rank": float(cohen_d(out_canon["mean_rank"], out_corrupt["mean_rank"])),
-        "n_examples": int(len(out_canon)),
-    }
-
-
-def ensure_output_dir(path):
-    output_dir = expand_path(path)
-    output_dir.mkdir(parents=True, exist_ok=True)
-    return output_dir
-
-
-def expand_path(path):
-    """Expand env vars and ~ in a path, returning a Path object."""
-    return Path(os.path.expandvars(str(path))).expanduser() if path else Path(".")
-
-
-def run_scs(
-    model,
-    data_path,
-    output_dir,
-    num_rows,
-    tensor_parallel_size,
-    max_num_seqs,
-    max_model_len,
-    batch_size,
-    dtype,
-    corruption_rate,
-    seed,
-):
-    llm, params = load_llm(
-        model=model,
-        max_num_seqs=max_num_seqs,
-        max_model_len=max_model_len,
-        tensor_parallel_size=tensor_parallel_size,
-        dtype=dtype,
-    )
-    data = load_dataset(
-        data_path=data_path,
-        num_rows=num_rows,
-        corruption_rate=corruption_rate,
-        seed=seed,
-    )
-
-    print(f"Loaded {len(data)} examples from {data_path}", flush=True)
-    print("Running canonical prompts", flush=True)
-    out_canon = run_column("prompt_canon", llm, params, data, batch_size=batch_size)
-    print("Running randomized prompts", flush=True)
-    out_random = run_column("prompt_random", llm, params, data, batch_size=batch_size)
-    print("Running corrupted prompts", flush=True)
-    out_corrupt = run_column("prompt_corrupt", llm, params, data, batch_size=batch_size)
-
-    write_dir = ensure_output_dir(output_dir)
-    out_canon.to_csv(write_dir / "lps_canonical.csv", index=False)
-    out_random.to_csv(write_dir / "lps_random.csv", index=False)
-    out_corrupt.to_csv(write_dir / "lps_corrupt.csv", index=False)
-
-    summary = summarize_results(out_canon, out_random, out_corrupt)
-    (write_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n")
-
-    print("Means:", flush=True)
-    print("CANON", out_canon[["mean_logprob", "mean_rank"]].mean(), flush=True)
-    print("RANDOM", out_random[["mean_logprob", "mean_rank"]].mean(), flush=True)
-    print("CORRUPT", out_corrupt[["mean_logprob", "mean_rank"]].mean(), flush=True)
-    print("----------", flush=True)
-    print("SCS logprobs", summary["scs_logprob"], flush=True)
-    print("SCS rank", summary["scs_rank"], flush=True)
-    print(f"Wrote outputs to {write_dir}", flush=True)
-
-
-def parse_args():
-    parser = argparse.ArgumentParser(description="Run the MiST SCS diagnostic on a SMILES dataset.")
-    parser.add_argument(
-        "--model",
-        type=str,
-        required=True,
-        help="Model checkpoint, Hugging Face model id, or local path to use with vLLM.",
-    )
-    parser.add_argument(
-        "--data-path",
-        "--data_dir",
-        dest="data_path",
-        type=str,
-        default=DEFAULT_DATA_PATH,
-        help="Path to the CSV used for SCS evaluation.",
-    )
-    parser.add_argument(
-        "--output-dir",
-        type=str,
-        default=DEFAULT_OUTPUT_DIR,
-        help="Directory where per-condition CSVs and summary.json will be written.",
-    )
-    parser.add_argument(
-        "--num-rows",
-        type=int,
-        default=10000,
-        help="Number of rows to evaluate from the input CSV.",
-    )
-    parser.add_argument(
-        "--tensor-parallel-size",
-        type=int,
-        default=1,
-        help="vLLM tensor parallel size. Use 1 for a single-GPU reviewer run.",
-    )
-    parser.add_argument(
-        "--max-num-seqs",
-        type=int,
-        default=5,
-        help="vLLM max_num_seqs value.",
-    )
-    parser.add_argument(
-        "--max-model-len",
-        type=int,
-        default=256,
-        help="vLLM max_model_len value.",
-    )
-    parser.add_argument(
-        "--batch-size",
-        type=int,
-        default=256,
-        help="Number of prompts evaluated per vLLM generate call.",
-    )
-    parser.add_argument(
-        "--dtype",
-        type=str,
-        default="half",
-        help="vLLM dtype value, for example half, bfloat16, or float32.",
-    )
-    parser.add_argument(
-        "--corruption-rate",
-        type=float,
-        default=0.2,
-        help="Fraction of grammar characters removed when building corrupted SMILES prompts.",
-    )
-    parser.add_argument(
-        "--seed",
-        type=int,
-        default=0,
-        help="Seed used for corrupted SMILES generation.",
-    )
-    return parser.parse_args()
+    print("SCC logprobs", lp_sc)
+    print("SCC rank", rk_sc)
 
 
 if __name__ == "__main__":
-    args = parse_args()
-    run_scs(
-        model=args.model,
-        data_path=expand_path(args.data_path),
-        output_dir=args.output_dir,
-        num_rows=args.num_rows,
-        tensor_parallel_size=args.tensor_parallel_size,
-        max_num_seqs=args.max_num_seqs,
-        max_model_len=args.max_model_len,
-        batch_size=args.batch_size,
-        dtype=args.dtype,
-        corruption_rate=args.corruption_rate,
-        seed=args.seed,
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Run LLM evaluation on SMILES data")
+    parser.add_argument("--model", type=str, required=True, help="Model checkpoint or path to use with vllm")
+    parser.add_argument(
+        "--data_dir",
+        type=str,
+        default="/iopsstor/store/cscs/swissai/a05/LIAC/data/CRLLM-PubChem/CRLLM-PubChem-compounds1M.csv",
+        help="Path to the data CSV",
     )
+    args = parser.parse_args()
+
+    main(args.model, args.data_dir)

--- a/src/open_r1/run_r1_grpo.py
+++ b/src/open_r1/run_r1_grpo.py
@@ -4,7 +4,6 @@ from datetime import datetime
 os.environ["HF_HUB_ENABLE_HF_TRANSFER"] = "1"
 from transformers import AutoTokenizer
 
-from paths import expand_path
 from tasks import CHEMTASKS
 from trl import GRPOConfig, ModelConfig, TrlParser, get_peft_config
 from utils import (
@@ -104,7 +103,6 @@ def grpo_function(model_args: ModelConfig, training_args: GRPOConfig):
 def main():
     parser = TrlParser((ModelConfig, ExtendedGRPOConfig))
     model_args, training_args = parser.parse_args_and_config()
-    training_args.dataset_id_or_path = expand_path(training_args.dataset_id_or_path)
     training_args = load_sampling_params_config(training_args)  # Load sampling parameters
     grpo_function(model_args, training_args)
 

--- a/src/open_r1/tasks/kinetic_data/tests/test_kinetic_data_classification.py
+++ b/src/open_r1/tasks/kinetic_data/tests/test_kinetic_data_classification.py
@@ -1,45 +1,117 @@
-from open_r1.tasks.kinetic_data.kinetic_data_classification import KineticDataClassification
+import re
+from pathlib import Path
+
+import pytest
+from transformers import AutoTokenizer
+
+import yaml
+from kinetic_data_classification import KineticDataClassification
+
+
+def load_config(config_path: str) -> dict:
+    """Load configuration from YAML file"""
+    with open(config_path, "r") as f:
+        config = yaml.safe_load(f)
+    return config
+
 
 response_wrong_format = """
-<think>Reasoning about the mechanism and data coverage.</think>
-<answer>M20</answer>
+    <think> Hi, I need to figure out the reaction class for these reaction data. Okay, let's see. The user provided four data runs with different initial conditions and time data, and their corresponding substrate and product concentrations. I remember that reaction classes like M1 to M20 are used to classify reactions based on their rate laws and intermediates.
+
+        First, I should look for the rate law patterns. Maybe they're both first-order with respect to the substrate ([S]₀) and the catalyst [S], so maybe second-order overall, which is M2 or M20.
+
+        But then I notice that some runs haven't reached 95% conversion yet, which might indicate the reaction is reversible. Hmm, for reversible reactions, M20 is used, which considers the equilibrium constant.
+
+        Looking at the data runs, in each one the product is initially present and then react, but doesn't always reach near 95% conversion. Still, the rate constants in run 4 are higher for the forward than reverse reactions, which suggests a tendency toward product formation, but without equilibration, the conversion isn't as high.
+
+        The product concentration increases over time, which supports the presence of a forward reaction, possibly consistent with M2, but without reaching 95% yet. Maybe M20 is the correct class because it involves both forward and reverse reactions.
+
+        I'm a bit confused because with forward and reverse reactions, the overall reaction is reversible, which is more accurately represented by M20. However, the product is accumulating but doesn't seem to peak as drastically as M20 would predict without equilibration.
+
+        I think M20 is the most appropriate class for these data points. It accounts for the competing rates and doesn't require equilibration, giving a clearer picture of the reaction kinetics.
+        </think>
+
+        Based on the reaction data provided, the reaction class is M20, which accounts for the competing rates of forward and reverse reactions, as well as the presence of a product with initial activation, avoiding equilibration to 95%.
+        <answer>M20</answer>
 """
 
 response_correct_format = """
-<think>Reasoning about M20 using data 1, data 2, and data 4 while comparing M1 and M20.</think>
-\\boxed{M20}
+    <think> Hi, I need to figure out the reaction class for these reaction data. Okay, let's see. The user provided four data runs with different initial conditions and time data, and their corresponding substrate and product concentrations. I remember that reaction classes like M1 to M20 are used to classify reactions based on their rate laws and intermediates.
+
+        First, I should look for the rate law patterns. Maybe they're both first-order with respect to the substrate ([S]₀) and the catalyst [S], so maybe second-order overall, which is M2 or M20.
+
+        But then I notice that some runs haven't reached 95% conversion yet, which might indicate the reaction is reversible. Hmm, for reversible reactions, M20 is used, which considers the equilibrium constant.
+
+        Looking at the data runs, in each one the product is initially present and then react, but doesn't always reach near 95% conversion. Still, the rate constants in run 4 are higher for the forward than reverse reactions, which suggests a tendency toward product formation, but without equilibration, the conversion isn't as high.
+
+        The product concentration increases over time, which supports the presence of a forward reaction, possibly consistent with M2, but without reaching 95% yet. Maybe M20 is the correct class because it involves both forward and reverse reactions.
+
+        I'm a bit confused because with forward and reverse reactions, the overall reaction is reversible, which is more accurately represented by M20. However, the product is accumulating but doesn't seem to peak as drastically as M20 would predict without equilibration.
+
+        I think M20 is the most appropriate class for these data points. It accounts for the competing rates and doesn't require equilibration, giving a clearer picture of the reaction kinetics.
+        </think>
+
+        Based on the reaction data provided, the reaction class is M20, which accounts for the competing rates of forward and reverse reactions, as well as the presence of a product with initial activation, avoiding equilibration to 95%.
+        \\boxed{M20}
 """
 
 
-def build_task():
-    return KineticDataClassification(dataset_id_or_path="unused")
+class TestAccuracyReward:
+    def setup_method(self):
+        # Load configuration
+        config_path = "/home/kuroki/sink/recipes/kinetic.yaml"
+        config = load_config(config_path)
 
+        self.classification_task = KineticDataClassification(
+            dataset_id_or_path=config["dataset_id_or_path"],
+            model_revision=config["model_revision"],
+            torch_dtype=config["torch_dtype"],
+            attn_implementation=config["attn_implementation"],
+            bf16=config["bf16"],
+            tf32=config["tf32"],
+        )
 
-def test_format_reward():
-    task = build_task()
-    assert task.format_reward([response_wrong_format, response_correct_format]) == [0.0, 1.0]
+        self.tokenizer = AutoTokenizer.from_pretrained(
+            "/work/liac/LLM_models/models--deepseek-ai--DeepSeek-R1-Distill-Qwen-1.5B/snapshots/530ca3e1ad39d440e182c2e4317aa40f012512fa",
+            revision=config["model_revision"],
+            trust_remote_code=False,
+        )
 
+    def test_prompt_format(self):
+        """
+        Test if the prompt includes \\boxed{} tags
+        """
+        self.classification_task.load()
+        self.classification_task.dataset_preprocess(self.tokenizer)
+        problem = self.classification_task.dataset["train"][0]["problem"]
+        question_template = self.classification_task.question_template
+        question = question_template.format(problem)
+        regex = r"\\boxed{(.*?)}"
+        match = re.search(regex, question)
+        assert len(match.groups()) == 1
 
-def test_accuracy_reward():
-    task = build_task()
-    rewards = task.accuracy_reward(
-        [response_wrong_format, response_correct_format],
-        ["M20", "M20"],
-    )
-    assert rewards == [0.0, 0.71]
+    def test_format_reward(self):
+        responses = [response_wrong_format, response_correct_format]
+        regex = r"<think>(.*?)</think>.*?\\boxed{(.*?)}"
+        match = re.search(regex, response_correct_format, re.DOTALL)
+        assert self.classification_task.format_reward(responses) == [
+            float(0),
+            float(1),
+        ]
 
+    def test_accuracy_reward(self):
+        responses = [response_wrong_format, response_correct_format]
+        rewards = self.classification_task.accuracy_reward(responses, ["M20", "M20"])
+        assert rewards == [float(0), float(0.71)]
 
-def test_preprocess_response():
-    task = build_task()
-    assert task.preprocess_response(response_correct_format) == "M20"
-    assert task.preprocess_response(response_wrong_format) == "NONE"
+    def test_preprocess_response(self):
+        ans = self.classification_task.preprocess_response(response_correct_format)
+        assert ans == "M20"
+        ans = self.classification_task.preprocess_response(response_wrong_format)
+        assert ans == "NONE"
 
+    def test_class_coverage_reward(self):
+        pass
 
-def test_class_coverage_reward():
-    task = build_task()
-    assert task.class_coverage_reward("M1 M2 M2 M20") == 3 / 20
-
-
-def test_data_coverage_reward():
-    task = build_task()
-    assert task.data_coverage_reward("data 1, data 2, and data 2") == 2 / 4
+    def test_data_coverage_reward(self):
+        pass

--- a/src/open_r1/tasks/kinetic_data/tests/test_kinetic_data_classification.py
+++ b/src/open_r1/tasks/kinetic_data/tests/test_kinetic_data_classification.py
@@ -1,117 +1,45 @@
-import re
-from pathlib import Path
-
-import pytest
-from transformers import AutoTokenizer
-
-import yaml
-from kinetic_data_classification import KineticDataClassification
-
-
-def load_config(config_path: str) -> dict:
-    """Load configuration from YAML file"""
-    with open(config_path, "r") as f:
-        config = yaml.safe_load(f)
-    return config
-
+from open_r1.tasks.kinetic_data.kinetic_data_classification import KineticDataClassification
 
 response_wrong_format = """
-    <think> Hi, I need to figure out the reaction class for these reaction data. Okay, let's see. The user provided four data runs with different initial conditions and time data, and their corresponding substrate and product concentrations. I remember that reaction classes like M1 to M20 are used to classify reactions based on their rate laws and intermediates.
-
-        First, I should look for the rate law patterns. Maybe they're both first-order with respect to the substrate ([S]₀) and the catalyst [S], so maybe second-order overall, which is M2 or M20.
-
-        But then I notice that some runs haven't reached 95% conversion yet, which might indicate the reaction is reversible. Hmm, for reversible reactions, M20 is used, which considers the equilibrium constant.
-
-        Looking at the data runs, in each one the product is initially present and then react, but doesn't always reach near 95% conversion. Still, the rate constants in run 4 are higher for the forward than reverse reactions, which suggests a tendency toward product formation, but without equilibration, the conversion isn't as high.
-
-        The product concentration increases over time, which supports the presence of a forward reaction, possibly consistent with M2, but without reaching 95% yet. Maybe M20 is the correct class because it involves both forward and reverse reactions.
-
-        I'm a bit confused because with forward and reverse reactions, the overall reaction is reversible, which is more accurately represented by M20. However, the product is accumulating but doesn't seem to peak as drastically as M20 would predict without equilibration.
-
-        I think M20 is the most appropriate class for these data points. It accounts for the competing rates and doesn't require equilibration, giving a clearer picture of the reaction kinetics.
-        </think>
-
-        Based on the reaction data provided, the reaction class is M20, which accounts for the competing rates of forward and reverse reactions, as well as the presence of a product with initial activation, avoiding equilibration to 95%.
-        <answer>M20</answer>
+<think>Reasoning about the mechanism and data coverage.</think>
+<answer>M20</answer>
 """
 
 response_correct_format = """
-    <think> Hi, I need to figure out the reaction class for these reaction data. Okay, let's see. The user provided four data runs with different initial conditions and time data, and their corresponding substrate and product concentrations. I remember that reaction classes like M1 to M20 are used to classify reactions based on their rate laws and intermediates.
-
-        First, I should look for the rate law patterns. Maybe they're both first-order with respect to the substrate ([S]₀) and the catalyst [S], so maybe second-order overall, which is M2 or M20.
-
-        But then I notice that some runs haven't reached 95% conversion yet, which might indicate the reaction is reversible. Hmm, for reversible reactions, M20 is used, which considers the equilibrium constant.
-
-        Looking at the data runs, in each one the product is initially present and then react, but doesn't always reach near 95% conversion. Still, the rate constants in run 4 are higher for the forward than reverse reactions, which suggests a tendency toward product formation, but without equilibration, the conversion isn't as high.
-
-        The product concentration increases over time, which supports the presence of a forward reaction, possibly consistent with M2, but without reaching 95% yet. Maybe M20 is the correct class because it involves both forward and reverse reactions.
-
-        I'm a bit confused because with forward and reverse reactions, the overall reaction is reversible, which is more accurately represented by M20. However, the product is accumulating but doesn't seem to peak as drastically as M20 would predict without equilibration.
-
-        I think M20 is the most appropriate class for these data points. It accounts for the competing rates and doesn't require equilibration, giving a clearer picture of the reaction kinetics.
-        </think>
-
-        Based on the reaction data provided, the reaction class is M20, which accounts for the competing rates of forward and reverse reactions, as well as the presence of a product with initial activation, avoiding equilibration to 95%.
-        \\boxed{M20}
+<think>Reasoning about M20 using data 1, data 2, and data 4 while comparing M1 and M20.</think>
+\\boxed{M20}
 """
 
 
-class TestAccuracyReward:
-    def setup_method(self):
-        # Load configuration
-        config_path = "/home/kuroki/sink/recipes/kinetic.yaml"
-        config = load_config(config_path)
+def build_task():
+    return KineticDataClassification(dataset_id_or_path="unused")
 
-        self.classification_task = KineticDataClassification(
-            dataset_id_or_path=config["dataset_id_or_path"],
-            model_revision=config["model_revision"],
-            torch_dtype=config["torch_dtype"],
-            attn_implementation=config["attn_implementation"],
-            bf16=config["bf16"],
-            tf32=config["tf32"],
-        )
 
-        self.tokenizer = AutoTokenizer.from_pretrained(
-            "/work/liac/LLM_models/models--deepseek-ai--DeepSeek-R1-Distill-Qwen-1.5B/snapshots/530ca3e1ad39d440e182c2e4317aa40f012512fa",
-            revision=config["model_revision"],
-            trust_remote_code=False,
-        )
+def test_format_reward():
+    task = build_task()
+    assert task.format_reward([response_wrong_format, response_correct_format]) == [0.0, 1.0]
 
-    def test_prompt_format(self):
-        """
-        Test if the prompt includes \\boxed{} tags
-        """
-        self.classification_task.load()
-        self.classification_task.dataset_preprocess(self.tokenizer)
-        problem = self.classification_task.dataset["train"][0]["problem"]
-        question_template = self.classification_task.question_template
-        question = question_template.format(problem)
-        regex = r"\\boxed{(.*?)}"
-        match = re.search(regex, question)
-        assert len(match.groups()) == 1
 
-    def test_format_reward(self):
-        responses = [response_wrong_format, response_correct_format]
-        regex = r"<think>(.*?)</think>.*?\\boxed{(.*?)}"
-        match = re.search(regex, response_correct_format, re.DOTALL)
-        assert self.classification_task.format_reward(responses) == [
-            float(0),
-            float(1),
-        ]
+def test_accuracy_reward():
+    task = build_task()
+    rewards = task.accuracy_reward(
+        [response_wrong_format, response_correct_format],
+        ["M20", "M20"],
+    )
+    assert rewards == [0.0, 0.71]
 
-    def test_accuracy_reward(self):
-        responses = [response_wrong_format, response_correct_format]
-        rewards = self.classification_task.accuracy_reward(responses, ["M20", "M20"])
-        assert rewards == [float(0), float(0.71)]
 
-    def test_preprocess_response(self):
-        ans = self.classification_task.preprocess_response(response_correct_format)
-        assert ans == "M20"
-        ans = self.classification_task.preprocess_response(response_wrong_format)
-        assert ans == "NONE"
+def test_preprocess_response():
+    task = build_task()
+    assert task.preprocess_response(response_correct_format) == "M20"
+    assert task.preprocess_response(response_wrong_format) == "NONE"
 
-    def test_class_coverage_reward(self):
-        pass
 
-    def test_data_coverage_reward(self):
-        pass
+def test_class_coverage_reward():
+    task = build_task()
+    assert task.class_coverage_reward("M1 M2 M2 M20") == 3 / 20
+
+
+def test_data_coverage_reward():
+    task = build_task()
+    assert task.data_coverage_reward("data 1, data 2, and data 2") == 2 / 4

--- a/src/open_r1/tasks/reactions/forward.py
+++ b/src/open_r1/tasks/reactions/forward.py
@@ -8,7 +8,6 @@ from rdkit import Chem, DataStructs
 from rdkit.Chem import AllChem
 
 from open_r1.download_data import download_data
-from open_r1.paths import expand_path
 
 from ..base import RLTask, SMILESBasedTask
 from .utils import tanimoto_sim
@@ -25,30 +24,16 @@ class ForwardReaction(SMILESBasedTask):
     random_log: Dict[str, Any] = {}
     printed_sample_prompt: bool = False
 
-    @staticmethod
-    def _has_local_reaction_files(dataset_dir: str) -> bool:
-        required_files = [
-            "src-train.txt",
-            "tgt-train.txt",
-            "src-test.txt",
-            "tgt-test.txt",
-        ]
-        return all(os.path.exists(os.path.join(dataset_dir, filename)) for filename in required_files)
-
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.dataset_id_or_path = expand_path(self.dataset_id_or_path)
         if not os.path.exists(self.dataset_id_or_path):
             os.makedirs(self.dataset_id_or_path)
-        if not self._has_local_reaction_files(self.dataset_id_or_path):
-            download_data(self.dataset_id_or_path)
+        download_data(self.dataset_id_or_path)
 
         self.src_train_file = os.path.join(self.dataset_id_or_path, "src-train.txt")
         self.tgt_train_file = os.path.join(self.dataset_id_or_path, "tgt-train.txt")
-        src_test_path = os.path.join(self.dataset_id_or_path, "src-test.txt")
-        tgt_test_path = os.path.join(self.dataset_id_or_path, "tgt-test.txt")
-        self.src_test_file = src_test_path if os.path.exists(src_test_path) else None
-        self.tgt_test_file = tgt_test_path if os.path.exists(tgt_test_path) else None
+        self.src_test_file = os.path.join(self.dataset_id_or_path, "src-test.txt") if "src-test.txt" else None
+        self.tgt_test_file = os.path.join(self.dataset_id_or_path, "tgt-test.txt") if "tgt-test.txt" else None
         self.question_template = (
             "You are an organic chemistry expert, and I have a task for you. "
             "Given the following reagents in SMILES notation, please predict the most likely product(s) of the reaction between them. "

--- a/src/open_r1/utils.py
+++ b/src/open_r1/utils.py
@@ -10,12 +10,6 @@ from pydantic import Field
 from trl import GRPOConfig, GRPOTrainer
 from vllm import SamplingParams
 
-try:
-    from .paths import sampling_params_dir
-except ImportError:  # pragma: no cover - script execution path
-    from paths import sampling_params_dir
-
-
 MetricFunc = Callable[[], dict]
 
 
@@ -27,7 +21,7 @@ class ExtendedGRPOTrainer(GRPOTrainer):
         metric_funcs: Optional[Union[MetricFunc, list[MetricFunc]]] = None,
         **kwargs_,
     ):
-        # Note: current TRL version used in this repository: 0.14.0
+        # Note: current trl library version used in the sink repo: 0.14.0
         super().__init__(*args_, args=args, **kwargs_)
 
         # Define metric functions to use (default is None)
@@ -77,7 +71,7 @@ class ExtendedGRPOTrainer(GRPOTrainer):
 
 @dataclass
 class ExtendedGRPOConfig(GRPOConfig):
-    dataset_id_or_path: str = "${MIST_DATA_DIR}/rxnpred/USPTO_480k_clean"
+    dataset_id_or_path: str = "/cache/data/"
     chem_task: str = "CountdownTask"
     task_mode: str = "base"
     task_kwargs: Dict[str, Any] = field(default_factory=dict)
@@ -132,31 +126,27 @@ def load_sampling_params_config(training_args: ExtendedGRPOConfig):
     :param training_args: Training arguments [ExtendedGRPOConfig]
     :return: Updated training arguments [ExtendedGRPOConfig]
     """
-    sampling_dir = sampling_params_dir()
+    sampling_params_dir = "/Documents/sink/sampling_params"
 
     # Read model_default_sampling_params.txt
     model_default_sampling_params = dict()
-    with open(sampling_dir / "model_default_sampling_params.txt", mode="r") as f:
+    with open(f"{sampling_params_dir}/model_default_sampling_params.txt", mode="r") as f:
         for line in f:
             if ":" not in line:
                 continue
             line_split = line.split(":")
-            assert len(line_split) == 2, (
-                "Invalid format in model_default_sampling_params.txt -> "
-                "each line should be in the format 'key: value' "
-                f"(with a single ':', found {len(line_split)-1} instead of 1)"
-            )
+            assert (
+                len(line_split) == 2
+            ), f"Invalid format in model_default_sampling_params.txt -> each line should be in the format 'key: value' (with a single ':', found {len(line_split)-1} instead of 1)"
             model_id = line_split[0].strip()
             sampling_params_config_name = line_split[1].strip()
-            assert model_id not in model_default_sampling_params, (
-                "Invalid format in model_default_sampling_params.txt -> " f"model_id {model_id} is duplicated"
-            )
+            assert (
+                model_id not in model_default_sampling_params
+            ), f"Invalid format in model_default_sampling_params.txt -> model_id {model_id} is duplicated"
             if sampling_params_config_name != "default":
-                config_path = sampling_dir / f"{sampling_params_config_name}.json"
-                assert config_path.is_file(), (
-                    "Invalid format in model_default_sampling_params.txt -> "
-                    f"sampling_params_config_name ({sampling_params_config_name}.json) does not exist"
-                )
+                assert os.path.isfile(
+                    f"{sampling_params_dir}/{sampling_params_config_name}.json"
+                ), f"Invalid format in model_default_sampling_params.txt -> sampling_params_config_name ({sampling_params_config_name}.json) does not exist"
             model_default_sampling_params[model_id] = sampling_params_config_name
 
     # Update training_args.sampling_params_config_name (if needed)
@@ -166,17 +156,14 @@ def load_sampling_params_config(training_args: ExtendedGRPOConfig):
 
     # Update training_args.sampling_params_config (if needed)
     if training_args.sampling_params_config_name != "default":
-        config_path = sampling_dir / f"{training_args.sampling_params_config_name}.json"
-        with open(config_path, mode="r") as handle:
-            sampling_params = json.load(handle)
+        sampling_params = json.load(
+            open(f"{sampling_params_dir}/{training_args.sampling_params_config_name}.json", mode="r")
+        )
         training_args.sampling_params_config = sampling_params
     else:
         # Ensure sampling_params/default.json does not exist (the default should never be modified)
-        default_path = sampling_dir / "default.json"
-        assert not default_path.is_file(), (
-            "The file sampling_params/default.json exists. The global "
-            "default sampling_params can't be overwritten, please remove "
-            "this file (or put the config in a new file)."
-        )
+        assert not os.path.isfile(
+            f"{sampling_params_dir}/default.json"
+        ), f"The file sampling_params/default.json exists. The global default sampling_params can't be overwritten, please remove this file (or put the config in a new file)."
 
     return training_args


### PR DESCRIPTION
## Reproducibility Assessment -- `david_eval`

**Author:** David Segura | **Commits:** 1 | **Files changed:** 8 | **+1,086 lines**

> **Status: NOT READY -- useful evaluation methodology, completely non-portable.**

---

### What this contributes

Eight standalone vLLM-based evaluation scripts in `evaluation/` for four reaction tasks, each with a base and retry variant:

| Script | Task |
|--------|------|
| `benchmarking_inversion-2.py` / `-retry.py` | MCQ: identify correct reaction (swapped reactants) |
| `benchmarking_naming-2.py` / `-retry.py` | Reaction class prediction (10 classes) |
| `benchmarking_replacement.py` / `-2-retry.py` | MCQ: identify correct reaction (modified reactions) |
| `benchmarking_truefalse-2.py` / `-retry.py` | True/False: is this reaction correct? |

Each script loads a CSV dataset, constructs MCQ/binary prompts, runs vLLM inference, extracts answers via regex, and computes accuracy metrics.

---

### Breaks / Blockers

| Issue | Severity |
|-------|----------|
| **`benchmarking_inversion-2-retry.py`: `needs_retry` referenced before definition** -- script crashes with NameError on first run | **Bug** |

### Reproducibility Gaps

| Gap | Details |
|-----|---------|
| **All 8 scripts use hardcoded absolute paths** | `/data/david/...`, `/data/share/sft_hf_3/` -- zero CLI args, no env vars, no config files |
| **No deterministic option shuffling** | MCQ scripts use `np.random.permutation()` without fixed seed -- option ordering varies between runs |
| **Massive code duplication** | ~60% identical boilerplate across 8 scripts (data loading, splitting, extraction, metrics) |
| **No tests** | Zero unit or integration tests |
| **No documentation** | No docstrings, no README explaining what models are targeted or how to interpret results |
| **Hardcoded model paths** | Specific to David's cluster environment |
| **Hardcoded tokenizer** | Qwen-specific stop tokens in some scripts |

### Relationship to other branches

- **`david_active_branch`** is the full dev branch -- contains these scripts plus result CSVs, reaction tasks, and CSCS infrastructure. Also contains **committed WandB API key** (security issue) and ~1.4M lines of result CSVs.
- **`david_kuma_sampling_param`** (PR #36) contains the 3 reaction task classes that these scripts evaluate
- The evaluation methodology overlaps with `evaluate.rxnpred.py` in `Vu_active_branch`

### What is needed for reviewer reproducibility

- [ ] Fix `benchmarking_inversion-2-retry.py` NameError
- [ ] Refactor 8 scripts into a single parameterized evaluation harness with CLI args for model path, data path, task type
- [ ] Add `np.random.seed()` for deterministic MCQ option shuffling
- [ ] Replace all hardcoded paths with CLI arguments or `${MIST_DATA_DIR}`
- [ ] Add a README documenting usage, expected inputs/outputs, and interpretation
- [ ] Add at least smoke tests for prompt construction and answer extraction logic
- [ ] Consider integrating with the existing `src/open_r1/` evaluation infrastructure rather than standalone scripts

:robot: Generated with [Claude Code](https://claude.com/claude-code)
