### PR TITLE
Add CCS diagnostic (paper metric)

### DIFF
--- a/src/open_r1/diagnostic/chemical_competence.py
+++ b/src/open_r1/diagnostic/chemical_competence.py
@@ -1,0 +1,140 @@
+import argparse
+import os
+
+import numpy as np
+import pandas as pd
+
+from open_r1.diagnostic.utils import cohen_d
+from open_r1.paths import expand_path
+from pydantic import BaseModel
+
+DEFAULT_DATA_PATH = "${MIST_DATA_DIR}/ccs/chemical_competence.tsv"
+DEFAULT_OUTPUT_DIR = "${MIST_OUTPUT_DIR}/ccs"
+
+
+def load_llm(model):
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(model=model, max_num_seqs=1, max_model_len=1024, tensor_parallel_size=2, gpu_memory_utilization=0.7)
+    params = SamplingParams(
+        temperature=0.0,
+        prompt_logprobs=1,
+        max_tokens=1,
+    )
+    return llm, params
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Chemical competence evaluation (CCS diagnostic)")
+    parser.add_argument("--model", type=str, required=True, help="Model name or path")
+    parser.add_argument(
+        "--data-path",
+        "--data_path",
+        dest="data_path",
+        type=str,
+        default=DEFAULT_DATA_PATH,
+        help="Path to the TSV data file for CCS evaluation.",
+    )
+    parser.add_argument(
+        "--outdir",
+        type=str,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Output directory for results.",
+    )
+    return parser.parse_args()
+
+
+def load_dataset(data_path, nrows=1000):
+    df = pd.read_csv(data_path, nrows=nrows, sep="\t")
+    return df
+
+
+class LogprobStat(BaseModel):
+    mean_logprob: float
+    mean_rank: float
+    n_tokens: int
+    prompt: str
+
+
+def run_column(col, llm, params, data):
+    def process_out(out):
+        try:
+            token_ids = out.prompt_token_ids[1:]
+            lps = out.prompt_logprobs[1:]
+
+            # vllm gives you logprobs for your token, and for rank1 token
+            token_lps = [v[x].logprob for v, x in zip(lps, token_ids)]
+            token_rank = [v[x].rank for v, x in zip(lps, token_ids)]
+
+            prompt = "".join([v[x].decoded_token for v, x in zip(lps, token_ids)])
+
+            return LogprobStat(
+                mean_logprob=np.mean(token_lps), mean_rank=np.mean(token_rank), n_tokens=len(token_ids), prompt=prompt
+            ).__dict__
+        except Exception:
+            return LogprobStat(mean_logprob=0, mean_rank=0, n_tokens=1000, prompt="").__dict__
+
+    out = llm.generate(data[col], params)
+    lps = [process_out(o) for o in out]
+
+    return pd.DataFrame(lps)
+
+
+def main():
+    args = parse_args()
+    data_path = expand_path(args.data_path)
+    write_dir = expand_path(args.outdir)
+    os.makedirs(write_dir, exist_ok=True)
+
+    with open(os.path.join(write_dir, "args.txt"), "w") as f:
+        f.write(str(args))
+
+    llm, params = load_llm(args.model)
+    data = load_dataset(data_path)
+
+    out_origin = run_column("output", llm, params, data)
+    out_corrupt = run_column("corrupted_output", llm, params, data)
+
+    out_origin.to_csv(os.path.join(write_dir, "lps_origin.csv"), index=False, sep="\t")
+    out_corrupt.to_csv(os.path.join(write_dir, "lps_corrupted.csv"), index=False, sep="\t")
+
+    # Report some metrics here (e.g. avg difference, diff of averages, relative to canon)
+    print("Means:")
+    print("ORIGIN", out_origin[["mean_logprob", "mean_rank"]].mean())
+    print("CORRUPT", out_corrupt[["mean_logprob", "mean_rank"]].mean())
+    print("----------")
+
+    print("Mean distribution diff:")
+    print(
+        "Origin to Corrupt",
+        (out_origin[["mean_logprob", "mean_rank"]] - out_corrupt[["mean_logprob", "mean_rank"]]).mean(),
+    )
+    print("----------")
+
+    print("Diff of means:")
+    print(
+        "Origin to Corrupt",
+        out_origin[["mean_logprob", "mean_rank"]].mean() - out_corrupt[["mean_logprob", "mean_rank"]].mean(),
+    )
+
+    lp_origin = out_origin["mean_logprob"]
+    rk_origin = out_origin["mean_rank"]
+    lp_corrupt = out_corrupt["mean_logprob"]
+    rk_corrupt = out_corrupt["mean_rank"]
+    lp_sc = cohen_d(lp_origin, lp_corrupt)
+    rk_sc = cohen_d(rk_origin, rk_corrupt)
+
+    print("CCS logprobs", lp_sc)
+    print("CCS rank", rk_sc)
+
+    res_outpath = os.path.join(write_dir, "final_results.txt")
+    with open(res_outpath, "w") as f:
+        f.write("Means:\n")
+        f.write(f"ORIGIN {out_origin[['mean_logprob','mean_rank']].mean()}\n")
+        f.write(f"CORRUPT {out_corrupt[['mean_logprob','mean_rank']].mean()}\n\n")
+        f.write(f"CCS logprobs: {lp_sc}\n")
+        f.write(f"CCS rank: {rk_sc}\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/open_r1/diagnostic/utils.py
+++ b/src/open_r1/diagnostic/utils.py
@@ -1,0 +1,8 @@
+from numpy import mean, sqrt, std
+
+
+def cohen_d(x, y):
+    nx = len(x)
+    ny = len(y)
+    dof = nx + ny - 2
+    return (mean(x) - mean(y)) / sqrt(((nx - 1) * std(x, ddof=1) ** 2 + (ny - 1) * std(y, ddof=1) ** 2) / dof)


### PR DESCRIPTION
## Summary

- Cherry-picks the Chemical Competence Score (CCS) diagnostic from `Vu_active_branch`
- CCS measures a model's ability to distinguish factually correct vs incorrect chemical statements, using Cohen's d effect size on contrastive logprob pairs
- Core metric reported in **Table 4** of the paper

## Changes

- `src/open_r1/diagnostic/chemical_competence.py` — main CCS evaluation script with CLI interface
- `src/open_r1/diagnostic/utils.py` — `cohen_d` helper (removed unused top-level vLLM import)

## Fixes applied during cherry-pick

- Made vLLM import lazy (inside `load_llm()`) to avoid import-time GPU allocation
- Removed unused `from vllm import LLM, SamplingParams` from `utils.py`
- Added `from open_r1.paths import expand_path` and use it on `data_path` and `outdir`
- Replaced hardcoded paths with `${MIST_DATA_DIR}` / `${MIST_OUTPUT_DIR}` defaults
- Fixed bare `except:` clause → `except Exception:`
- Moved `from pydantic import BaseModel` to top-level imports
- Formatted with `black --line-length 119` and `isort`

## Test plan

- [ ] Verify `python -c "from open_r1.diagnostic.chemical_competence import main"` imports cleanly (without GPU)
- [ ] Run on a small TSV to confirm CCS scores are computed correctly